### PR TITLE
Ajout de l'export vers discourse pour le secretaire et le president de séance.

### DIFF
--- a/application/assets/js/perpage/meeting_agenda.js
+++ b/application/assets/js/perpage/meeting_agenda.js
@@ -330,8 +330,6 @@ function addMeetingHandlers() {
 		var meetingId = $(".meeting").data("id");
 		$.post("meeting_api.php?method=do_changeMeeting", {meetingId: meetingId, property: "mee_status", text: "closed"},
 				function(data) {}, "json");
-		$.post("meeting_api.php?method=do_discourseCr", {meetingId: meetingId, property: "category", text: meetingCategory},
-				function(data) {}, "json");
 	});
 
 	$("#meeting_rights_list").on("click", "input", function() {

--- a/application/assets/js/perpage/meeting_agenda.js
+++ b/application/assets/js/perpage/meeting_agenda.js
@@ -226,6 +226,7 @@ function updateMeeting(meeting) {
 		$("#meeting-status-panel button.btn-close-meeting").hide();
 		$("#meeting-status-panel button.btn-delete-meeting").hide();
 //		$("#meeting-status-panel span.closed-meeting").hide();
+		$("#btn-export-discourse").hide();
 	}
 
 	if (meeting.mee_datetime) {

--- a/application/assets/js/perpage/meeting_export.js
+++ b/application/assets/js/perpage/meeting_export.js
@@ -18,9 +18,8 @@
 */
 function loadExport(format, meeting_id, textarea){
   exportModal = $('#export_container_' + format);
-	exportClose = $('#export_close_' + format);
   $('#iframe_' + format).attr("src", "meeting/do_export.php?template=" + format + "&id=" + meeting_id + "&textarea=" + textarea);
-  if(format=='html'){$('#newpage').attr("href", $('#iframe_' + format).attr("src"));}
+  if(format=='html'){$('#newpage_html').attr("href", $('#iframe_' + format).attr("src"));}
   exportModal.show();
 }
 function closeExport(exportModal){
@@ -30,7 +29,7 @@ function closeExport(exportModal){
 
 $('.btnShowExport').click(function(){
   format = $(this).data("format");
-  if (format=='markdown'){
+  if (format=='markdown' || format=='discourse' || format=='html-code'){
     textarea = 'true';
   } else {
     textarea = 'false';
@@ -40,7 +39,6 @@ $('.btnShowExport').click(function(){
     $('#html-code').removeClass('btn-active');
   }
   if (format=='html-code'){
-    textarea = 'true';
     format = 'html';
     $('#html-code').addClass('btn-active');
     $('#rendering').removeClass('btn-active');
@@ -64,3 +62,19 @@ $(window).on('click', function(event){
         closeExport(exportModal);
     }
 });
+
+// $('#discourseSendBtn').click(function(){
+//   $('#discourseSendBtn').hide();
+//   $('#discourseCancel').css('display', 'inline-block');
+//   $('#iframe_discourse').hide();
+//   $('#discourseForm').show();
+//   $('#newpage_discourse').hide();
+// });
+//
+// $('#discourseCancel').click(function(){
+//   $('#discourseSendBtn').show();
+//   $('#discourseCancel').hide();
+//   $('#iframe_discourse').show();
+//   $('#discourseForm').hide();
+//   $('#newpage_discourse').show();
+// });

--- a/application/assets/js/perpage/meeting_export.js
+++ b/application/assets/js/perpage/meeting_export.js
@@ -62,19 +62,3 @@ $(window).on('click', function(event){
         closeExport(exportModal);
     }
 });
-
-// $('#discourseSendBtn').click(function(){
-//   $('#discourseSendBtn').hide();
-//   $('#discourseCancel').css('display', 'inline-block');
-//   $('#iframe_discourse').hide();
-//   $('#discourseForm').show();
-//   $('#newpage_discourse').hide();
-// });
-//
-// $('#discourseCancel').click(function(){
-//   $('#discourseSendBtn').show();
-//   $('#discourseCancel').hide();
-//   $('#iframe_discourse').show();
-//   $('#discourseForm').hide();
-//   $('#newpage_discourse').show();
-// });

--- a/application/assets/js/perpage/meeting_export_discourse.js
+++ b/application/assets/js/perpage/meeting_export_discourse.js
@@ -1,3 +1,21 @@
+/*
+	Copyright 2017 Nino Treyssat-Vincent, Parti Pirate
+
+	This file is part of Congressus.
+
+    Congressus is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Congressus is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+*/
 $( "#discourseSubmit" ).click(function( event ) {
   event.preventDefault();
 

--- a/application/assets/js/perpage/meeting_export_discourse.js
+++ b/application/assets/js/perpage/meeting_export_discourse.js
@@ -1,0 +1,16 @@
+$( "#discourseSubmit" ).click(function( event ) {
+  event.preventDefault();
+
+  var $form = $( this ),
+    discourse_title = $('input[name="discourse_title"]').val(),
+    discourse_category = $('select[name="discourse_category"]').val(),
+    meetingId = meeting_id;
+    url = "meeting_api.php?method=do_discoursePost";
+
+  var posting = $.post( url, { discourse_title: discourse_title, discourse_category: discourse_category, meetingId: meetingId } );
+
+	posting.done(function( data ) {
+		var content = $(data);
+		$("#result").empty().append(content);
+	});
+});

--- a/application/config/discourse.structure.php
+++ b/application/config/discourse.structure.php
@@ -1,0 +1,61 @@
+<?php /*
+	Copyright 2017 Nino Treyssat-Vincent, Parti Pirate
+
+	This file is part of Congressus.
+
+	Congressus is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Congressus is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+*/
+require_once("engine/discourse/DiscourseAPI.php");
+
+$discourseApi = new richp10\discourseAPI\DiscourseAPI("discourse.partipirate.org", $config["discourse"]["api_key"], "https");
+
+$categories = $discourseApi->getSite()->apiresult->categories;
+
+foreach ($categories as $category) {
+  if (isset($category->parent_category_id)){
+    $categories_all[$category->parent_category_id]['subcategory'][$category->id]['id'] = $category->id;
+    $categories_all[$category->parent_category_id]['subcategory'][$category->id]['slug'] = $category->slug;
+    $categories_all[$category->parent_category_id]['subcategory'][$category->id]['name'] = $category->name;
+  } else {
+    $categories_all[$category->id]['id'] = $category->id;
+    $categories_all[$category->id]['slug'] = $category->slug;
+    $categories_all[$category->id]['name'] = $category->name;
+  }
+}
+// TODO: Add a configuration pannel for the administrator to edit theses values.
+$allowed_categories = array(
+  // "Ektek",
+  // "CR - CN",
+  "Sandbox"
+);
+
+
+unset($categories);
+foreach ($categories_all as $categoy) {
+  if (in_array($categoy['name'], $allowed_categories)){
+    $categories[$categoy['id']]['id'] = $categoy['id'];
+    $categories[$categoy['id']]['slug'] = $categoy['slug'];
+    $categories[$categoy['id']]['name'] = $categoy['name'];
+  }
+  if (isset($categoy['subcategory'])) {
+    foreach ($categoy['subcategory'] as $subcategoy) {
+      if (in_array($subcategoy['name'], $allowed_categories)){
+        $categories[$subcategoy['id']]['id'] = $subcategoy['id'];
+        $categories[$subcategoy['id']]['slug'] = $subcategoy['slug'];
+        $categories[$subcategoy['id']]['name'] = $categoy['name'] . " : " . $subcategoy['name'];
+      }
+    }
+  }
+}
+?>

--- a/application/config/discourse.structure.php
+++ b/application/config/discourse.structure.php
@@ -16,6 +16,13 @@
 	You should have received a copy of the GNU General Public License
 	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
+// TODO: Add a configuration pannel for the administrator to edit theses values.
+$allowed_categories = array( // Add here the categories allowed for export.
+  // "Ektek",
+  // "CR - CN",
+  "Sandbox"
+);
+
 require_once("engine/discourse/DiscourseAPI.php");
 
 $discourseApi = new richp10\discourseAPI\DiscourseAPI("discourse.partipirate.org", $config["discourse"]["api_key"], "https");
@@ -33,13 +40,6 @@ foreach ($categories as $category) {
     $categories_all[$category->id]['name'] = $category->name;
   }
 }
-// TODO: Add a configuration pannel for the administrator to edit theses values.
-$allowed_categories = array(
-  // "Ektek",
-  // "CR - CN",
-  "Sandbox"
-);
-
 
 unset($categories);
 foreach ($categories_all as $categoy) {

--- a/application/config/mumble.structure.php
+++ b/application/config/mumble.structure.php
@@ -1,4 +1,22 @@
-<?php
+<?php /*
+	Copyright 2017 Nino Treyssat-Vincent, Parti Pirate
+
+	This file is part of Congressus.
+
+	Congressus is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Congressus is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 $mumble_server = "mumble.partipirate.org";
 $mumble_version = "1.2.0";
 $mumble_title = "Parti%20Pirate";

--- a/application/export_discourse.php
+++ b/application/export_discourse.php
@@ -37,89 +37,81 @@ else {
 $userId = SessionUtils::getUserId($_SESSION);
 ?>
 <div class="container theme-showcase meeting" role="main">
-<ol class="breadcrumb">
-  <li><a href="index.php"><?php echo lang("breadcrumb_index"); ?></a></li>
-  <li><a href="meeting.php?id=<?php echo $meeting["mee_id"]; ?>"><?php echo $meeting["mee_label"]; ?></a></li>
-  <li class="active">Export Discourse</li>
-</ol>
+	<ol class="breadcrumb">
+	  <li><a href="index.php"><?php echo lang("breadcrumb_index"); ?></a></li>
+	  <li><a href="meeting.php?id=<?php echo $meeting["mee_id"]; ?>"><?php echo $meeting["mee_label"]; ?></a></li>
+	  <li class="active"><?php echo lang("export_discourse"); ?></li>
+	</ol>
 
-<?php
-if (!isset($userId)) {?>
-	<div class="container">
-		<div class="jumbotron alert-danger">
-			<h2>Please Login</h2>
-			<p>Guests are not allowed to use this function</p>
-			<p><a class='btn btn-danger btn-lg' href='connect.php' role='button'>Login</a></p>
+	<?php
+	if (!isset($userId)) {?>
+		<div class="container">
+			<div class="jumbotron alert-danger">
+				<h2><?php echo lang("export_login_ask"); ?></h2>
+				<p><?php echo lang("export_permission_guests"); ?></p>
+				<p><a class='btn btn-danger btn-lg' href='connect.php' role='button'><?php echo lang("login_title"); ?></a></p>
+			</div>
 		</div>
-	</div>
-  <?php die("error : not_enough_right");
-} elseif (($userId !== $meeting["mee_president_member_id"]) AND ($userId !== $meeting["mee_secretary_member_id"])) {?>
-	<div class="container">
-		<div class="jumbotron alert-danger">
-			<h2>You have not enough rights</h2>
-			<p>To avoid spam, only the president and the secretary of the session can export to Discourse.</p>
-			<p><a class='btn btn-danger btn-lg' href='meeting.php?id=<?php echo $meeting["mee_id"]; ?>' role='button'>Back</a></p>
+	  <?php die("error : not_enough_right");
+	} elseif (($userId !== $meeting["mee_president_member_id"]) AND ($userId !== $meeting["mee_secretary_member_id"])) {?>
+		<div class="container">
+			<div class="jumbotron alert-danger">
+				<h2><?php echo lang("export_permission"); ?></h2>
+				<p><?php echo lang("export_permission_description"); ?></p>
+				<p><a class='btn btn-danger btn-lg' href='meeting.php?id=<?php echo $meeting["mee_id"]; ?>' role='button'><?php echo lang("common_back"); ?></a></p>
+			</div>
 		</div>
+		<?php die("error : not_enough_right");
+	} ?>
+
+	<p class="col-md-12"><?php echo lang("export_description"); ?></p>
+
+	<div class="col-xs-12 col-md-6">
+	  <h2><?php echo lang("export_preview"); ?> :</h2>
+	  <iframe width="100%" id="iframe_discourse" src="meeting/do_export.php?template=discourse&id=<?php echo $meeting["mee_id"]; ?>&textarea=true"><?php echo lang("export_iframes"); ?></iframe>
 	</div>
-	<?php die("error : not_enough_right");
-} ?>
 
-<p class="col-md-12">Le compte rendu sera publié par Congressus dans la catégorie choisie ci-dessous.</p>
+	<div class="col-xs-12 col-md-6">
+	  <h2><?php echo lang("export_send_discourse"); ?> :</h2>
 
-<div class="col-xs-12 col-md-6">
-  <h2>Preview :</h2>
-  <iframe width="100%" id="iframe_discourse" src="meeting/do_export.php?template=discourse&id=<?php echo $meeting["mee_id"]; ?>&textarea=true"><?php echo lang("export_iframes"); ?></iframe>
-</div>
-<div class="col-xs-12 col-md-6">
-  <h2>Send to Discourse :</h2>
-    <form action="meeting_api.php?method=do_discourseCr" method="post" class="form-horizontal" id="export-to-discourse">
-      <div class="form-group">
-        <label for="discourse_title" class="col-md-4 control-label"><?php echo lang("meeting_name"); ?> :</label>
-        <div class="col-md-6">
-          <input type="text" class="form-control input-md" id="discourse_title" name="discourse_title" value="[CR] <?php echo $meeting["mee_label"];?> du <?php echo @$start->format(lang("date_format"))?>"/>
-        </div>
-      </div>
-      <div class="form-group" id="loc_channel_form">
-        <label for="discourse_category" class="col-md-4 control-label">Category : </label>
-        <div class="col-md-6">
-          <select class="form-control input-md" id="discourse_category" name="discourse_category">
-            <?php
-            foreach ($categories as $categoy) {
-                echo "<option value='$categoy[id]'>$categoy[name]</option>";
-            }
-            ?>
-          </select>
-        </div>
-      </div>
-      <div class="row text-center">
-        <button id="discourseSubmit" type="submit" class="btn btn-primary"><?php echo lang("common_create"); ?></button>
-      </div>
+	    <form action="meeting_api.php?method=do_discoursePost" method="post" class="form-horizontal" id="export-to-discourse">
 
-    </form>
-  </div>
+	      <div class="form-group">
+	        <label for="discourse_title" class="col-md-4 control-label"><?php echo lang("meeting_name"); ?> :</label>
+	        <div class="col-md-6">
+	          <input type="text" class="form-control input-md" id="discourse_title" name="discourse_title" value="[CR] <?php echo $meeting["mee_label"];?> du <?php echo @$start->format(lang("date_format"))?>"/>
+	        </div>
+	      </div>
 
-<div id="result"></div>
+	      <div class="form-group" id="loc_channel_form">
+	        <label for="discourse_category" class="col-md-4 control-label"><?php echo lang("export_category"); ?> : </label>
+	        <div class="col-md-6">
+	          <select class="form-control input-md" id="discourse_category" name="discourse_category">
+	            <?php
+	            foreach ($categories as $categoy) {
+	                echo "<option value='$categoy[id]'>$categoy[name]</option>";
+	            }
+	            ?>
+	          </select>
+	        </div>
+	      </div>
+
+	      <div class="row text-center">
+	        <button id="discourseSubmit" type="submit" class="btn btn-primary"><?php echo lang("common_create"); ?></button>
+	      </div>
+
+	    </form>
+	  </div>
+
+	<div id="result"></div>
+
 </div>
 <div class="lastDiv"></div>
+
 <?php include("footer.php");?>
+
 <script>
-$( "#discourseSubmit" ).click(function( event ) {
-  event.preventDefault();
-
-  var $form = $( this ),
-    discourse_title = $('input[name="discourse_title"]').val(),
-    discourse_category = $('select[name="discourse_category"]').val(),
-    meetingId = <?php echo $meeting["mee_id"]; ?>,
-    url = "meeting_api.php?method=do_discourseCr";
-    alert(discourse_title);
-
-  var posting = $.post( url, { discourse_title: discourse_title, discourse_category: discourse_category, meetingId: meetingId } );
-
-	posting.done(function( data ) {
-		var content = $(data);
-		$("#result").empty().append(content);
-	});
-});
-
-
+var meeting_id = "<?php echo $meeting["mee_id"]; ?>";
 </script>
+
+<script src="assets/js/perpage/meeting_export_discourse.js"></script>

--- a/application/export_discourse.php
+++ b/application/export_discourse.php
@@ -1,0 +1,98 @@
+<?php /*
+	Copyright 2017 Nino Treyssat-Vincent, Parti Pirate
+
+	This file is part of Congressus.
+
+	Congressus is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Congressus is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+*/
+include_once("header.php");
+
+include_once("config/discourse.structure.php");
+
+if (!$meeting) {
+	// Ask for creation
+	$meeting = array("mee_label" => lang("meeting_eventNew"));
+}
+else {
+	$start = new DateTime($meeting["mee_datetime"]);
+	$end = new DateTime($meeting["mee_datetime"]);
+	$duration = new DateInterval("PT" . ($meeting["mee_expected_duration"] ? $meeting["mee_expected_duration"] : 60) . "M");
+	$end = $end->add($duration);
+
+	if ($meeting["loc_type"] == "framatalk") {
+		$framachan = sha1($meeting["mee_id"] . "framatalk" . $meeting["mee_id"]);
+	}
+}
+
+?>
+
+<ol class="breadcrumb">
+  <li><a href="index.php"><?php echo lang("breadcrumb_index"); ?></a></li>
+  <li><?php echo $meeting["mee_label"]; ?></li>
+  <li class="active">Export Discourse</li>
+</ol>
+
+<p class="col-md-12">Le compte rendu sera publié par Congressus dans la catégorie choisie ci-dessous.</p>
+
+<div class="col-xs-12 col-md-6">
+  <h2>Preview :</h2>
+  <iframe width="100%" id="iframe_discourse" src="meeting/do_export.php?template=discourse&id=<?php echo $meeting["mee_id"]; ?>&textarea=true"><?php echo lang("export_iframes"); ?></iframe>
+</div>
+<div class="col-xs-12 col-md-6">
+  <h2>Send to Discourse :</h2>
+    <form action="meeting_api.php?method=do_discourseCr" method="post" class="form-horizontal" id="export-to-discourse">
+      <div class="form-group">
+        <label for="discourse_title" class="col-md-4 control-label"><?php echo lang("meeting_name"); ?> :</label>
+        <div class="col-md-6">
+          <input type="text" class="form-control input-md" id="discourse_title" name="discourse_title" value="[CR] <?php echo $meeting["mee_label"];?> du <?php echo @$start->format(lang("date_format"))?>"/>
+        </div>
+      </div>
+      <div class="form-group" id="loc_channel_form">
+        <label for="discourse_category" class="col-md-4 control-label">Category : </label>
+        <div class="col-md-6">
+          <select class="form-control input-md" id="discourse_category" name="discourse_category">
+            <?php
+            foreach ($categories as $categoy) {
+                echo "<option value='$categoy[id]'>$categoy[name]</option>";
+            }
+            ?>
+          </select>
+        </div>
+      </div>
+      <div class="row text-center">
+        <button id="discourseSubmit" type="submit" class="btn btn-primary"><?php echo lang("common_create"); ?></button>
+      </div>
+
+    </form>
+  </div>
+
+<div id="null"></div>
+
+<script>
+$( "#discourseSubmit" ).click(function( event ) {
+  event.preventDefault();
+
+  var $form = $( this ),
+    discourse_title = $('input[name="discourse_title"]').val(),
+    discourse_category = $('select[name="discourse_category"]').val(),
+    meetingId = <?php echo $meeting["mee_id"]; ?>,
+    url = "meeting_api.php?method=do_discourseCr";
+    alert(discourse_title);
+
+  $.post( url, { discourse_title: discourse_title, discourse_category: discourse_category, meetingId: meetingId } );
+
+});
+
+
+</script>

--- a/application/export_discourse.php
+++ b/application/export_discourse.php
@@ -34,14 +34,35 @@ else {
 		$framachan = sha1($meeting["mee_id"] . "framatalk" . $meeting["mee_id"]);
 	}
 }
-
+$userId = SessionUtils::getUserId($_SESSION);
 ?>
-
+<div class="container theme-showcase meeting" role="main">
 <ol class="breadcrumb">
   <li><a href="index.php"><?php echo lang("breadcrumb_index"); ?></a></li>
-  <li><?php echo $meeting["mee_label"]; ?></li>
+  <li><a href="meeting.php?id=<?php echo $meeting["mee_id"]; ?>"><?php echo $meeting["mee_label"]; ?></a></li>
   <li class="active">Export Discourse</li>
 </ol>
+
+<?php
+if (!isset($userId)) {?>
+	<div class="container">
+		<div class="jumbotron alert-danger">
+			<h2>Please Login</h2>
+			<p>Guests are not allowed to use this function</p>
+			<p><a class='btn btn-danger btn-lg' href='connect.php' role='button'>Login</a></p>
+		</div>
+	</div>
+  <?php die("error : not_enough_right");
+} elseif (($userId !== $meeting["mee_president_member_id"]) AND ($userId !== $meeting["mee_secretary_member_id"])) {?>
+	<div class="container">
+		<div class="jumbotron alert-danger">
+			<h2>You have not enough rights</h2>
+			<p>To avoid spam, only the president and the secretary of the session can export to Discourse.</p>
+			<p><a class='btn btn-danger btn-lg' href='meeting.php?id=<?php echo $meeting["mee_id"]; ?>' role='button'>Back</a></p>
+		</div>
+	</div>
+	<?php die("error : not_enough_right");
+} ?>
 
 <p class="col-md-12">Le compte rendu sera publié par Congressus dans la catégorie choisie ci-dessous.</p>
 
@@ -77,8 +98,10 @@ else {
     </form>
   </div>
 
-<div id="null"></div>
-
+<div id="result"></div>
+</div>
+<div class="lastDiv"></div>
+<?php include("footer.php");?>
 <script>
 $( "#discourseSubmit" ).click(function( event ) {
   event.preventDefault();
@@ -90,8 +113,12 @@ $( "#discourseSubmit" ).click(function( event ) {
     url = "meeting_api.php?method=do_discourseCr";
     alert(discourse_title);
 
-  $.post( url, { discourse_title: discourse_title, discourse_category: discourse_category, meetingId: meetingId } );
+  var posting = $.post( url, { discourse_title: discourse_title, discourse_category: discourse_category, meetingId: meetingId } );
 
+	posting.done(function( data ) {
+		var content = $(data);
+		$("#result").empty().append(content);
+	});
 });
 
 

--- a/application/export_html.php
+++ b/application/export_html.php
@@ -25,7 +25,7 @@
       <div class="navbar-header pull-left">
         <a id="rendering" data-format="html" class="btnShowExport hidden-xs btn btn-default navbar-btn btn-active" href="#"><?php echo lang("export_rendering"); ?></a>
         <a id="html-code" data-format="html-code" class="btnShowExport hidden-xs btn btn-default navbar-btn" href="#">Code HTML</a>
-        <a id="newpage" class="btn btn-default navbar-btn" href="meeting/do_export.php?template=html&id=<?php echo $meeting["mee_id"]; ?>?textarea=false" target="_blank"><?php echo lang("export_open"); ?></a>
+        <a id="newpage_html" class="btn btn-default navbar-btn" href="meeting/do_export.php?template=html&id=<?php echo $meeting["mee_id"]; ?>?textarea=false" target="_blank"><?php echo lang("export_open"); ?></a>
       </div>
       <div class="navbar-header pull-right">
         <a title="<?php echo lang("common_close"); ?>" class="btn btn-default navbar-btn exportClose" href="#"><span class="glyphicon glyphicon-remove"></span></a>

--- a/application/header.php
+++ b/application/header.php
@@ -91,7 +91,7 @@ $connection = openConnection();
 <!DOCTYPE html>
 <html lang="<?php echo $language; ?>">
 <head>
-	<?php if (basename($_SERVER["SCRIPT_FILENAME"])== "meeting.php") {
+	<?php if ((basename($_SERVER["SCRIPT_FILENAME"])== "meeting.php") OR basename($_SERVER["SCRIPT_FILENAME"])== "export_discourse.php") {
 	require_once("engine/bo/MeetingBo.php");
 
 	$meetingBo = MeetingBo::newInstance($connection);

--- a/application/language/en/main.php
+++ b/application/language/en/main.php
@@ -23,6 +23,7 @@ $lang["fulldate_format"] = "dddd DD/MM/YYYY";
 $lang["datetime_format"] = "the {date} at {time}";
 
 $lang["common_ask_for_modification"] = "Ask modification";
+$lang["common_back"] = "Back";
 $lang["common_connect"] = "Connect";
 $lang["common_close"] = "Close";
 $lang["common_create"] = "Create";
@@ -177,6 +178,18 @@ $lang["motion_ballot_majority_50"] = "Simple majority";
 $lang["motion_ballot_majority_66"] = "66% majority";
 $lang["motion_ballot_majority_80"] = "80% majority";
 
+$lang["export_login_ask"] = "Please Login";
+$lang["export_category"] = "Category";
+$lang["export_category_forbidden"] = "Error : Unauthorized category";
+$lang["export_description"] = "The report will be published on Discourse by Congressus in the choosen category.";
+$lang["export_discourse"] = "Export on Discourse";
+$lang["export_discourse_success"] = "The report has been published at the following adresse :";
+$lang["export_discourse_fail"] = "Error : The report hasn't been published.";
+$lang["export_preview"] = "Preview";
+$lang["export_send_discourse"] = "Send to Discourse";
+$lang["export_permission"] = "You have not enough rights";
+$lang["export_permission_description"] = "To avoid spam, only the president and the secretary of the session can export to Discourse.";
+$lang["export_permission_guests"] = "Guests are not allowed to use this function";
 $lang["export_rendering"] = "Rendering";
 $lang["export_open"] = "Open in a new page";
 $lang["export_iframe"] = "Please enable iframes";

--- a/application/language/fr/main.php
+++ b/application/language/fr/main.php
@@ -23,6 +23,7 @@ $lang["fulldate_format"] = "dddd DD/MM/YYYY";
 $lang["datetime_format"] = "le {date} à {time}";
 
 $lang["common_ask_for_modification"] = "Demander modification";
+$lang["common_back"] = "Retour";
 $lang["common_connect"] = "Connecter";
 $lang["common_close"] = "Fermer";
 $lang["common_create"] = "Créer";
@@ -173,6 +174,18 @@ $lang["myMeetings_deleted"] = "Réunions supprimées";
 $lang["myMeetings_open"] = "Réunions en cours";
 $lang["myMeetings_waiting"] = "Prochaines réunions";
 
+$lang["export_description"] = "Le compte rendu sera publié par Congressus dans la catégorie choisie ci-dessous.";
+$lang["export_login_ask"] = "Merci de vous connecter";
+$lang["export_category"] = "Categorie";
+$lang["export_category_forbidden"] = "Erreur : Catégorie non autorisée";
+$lang["export_discourse"] = "Exporter sur Discourse";
+$lang["export_discourse_success"] = "Le compte rendu a été publié à l'adresse suivante :";
+$lang["export_discourse_fail"] = "Erreur : Le compte rendu n'a pas été publié.";
+$lang["export_preview"] = "Aperçu";
+$lang["export_send_discourse"] = "Envoyer sur Discourse";
+$lang["export_permission"] = "Vous n'avez pas assez d'autorisations";
+$lang["export_permission_description"] = "Pour éviter le spam, seul le président et le secretaire de séance ont le droit d'exporter sur Discourse.";
+$lang["export_permission_guests"] = "Les invités ne sont pas autorisés à utiliser cette fonction";
 $lang["export_rendering"] = "Rendu";
 $lang["export_open"] = "Ouvrir dans une nouvelle page";
 $lang["export_iframes"] = "Merci d'activer les iframes";

--- a/application/meeting.php
+++ b/application/meeting.php
@@ -181,12 +181,15 @@ if (!$userId) {
 					<br />
 					<span class="closed-meeting simply-hidden"><?php echo lang("meeting_closed"); ?></span>
 					<br class="export-br simply-hidden">
-					<button data-format="html" class="btnShowExport export-link export-html simply-hidden btn btn-success">Export HTML</button>
-					<button data-format="pdf" class="btnShowExport export-link export-html simply-hidden btn btn-success">Export PDF</button>
-					<button data-format="markdown" class="btnShowExport export-link export-html simply-hidden btn btn-success">Export Wiki</button>
+					<button data-format="html" class="btnShowExport export-link simply-hidden btn btn-success">Export HTML</button>
+					<button data-format="pdf" class="btnShowExport export-link simply-hidden btn btn-success">Export PDF</button>
+					<button data-format="markdown" class="btnShowExport export-link simply-hidden btn btn-success">Export Wiki</button>
 					<!-- <a href="meeting/do_export.php?template=html&id=<?php echo $meeting["mee_id"]; ?>" target="_blank" class="export-link export-html simply-hidden">Export HTML</a>
 					<a href="meeting/do_export.php?template=pdf&id=<?php echo $meeting["mee_id"]; ?>" target="_blank" class="export-link export-pdf simply-hidden">Export PDF</a>
 					<a href="meeting/do_export.php?template=markdown&id=<?php echo $meeting["mee_id"]; ?>" target="_blank" class="export-link export-markdown simply-hidden">Export Markdown</a> -->
+					<div class="row" style="margin-top:5px;">
+						<a class="export-link simply-hidden btn btn-primary" href="export_discourse.php?id=<?php echo $meeting["mee_id"]; ?>" target="_blank" style="display:inline-block;">Export on Discourse <span class="glyphicon glyphicon-share"></span></a>
+					</div>
 				</div>
 			</div>
 		</div>
@@ -627,9 +630,9 @@ if (!$userId) {
 
 
 </templates>
-<?php include("export_html.php");?>
 <?php include("export_pdf.php");?>
 <?php include("export_markdown.php");?>
+<?php include("export_html.php");?>
 
 <div class="modal fade" tabindex="-1" role="dialog" id="start-meeting-modal">
   <div class="modal-dialog">

--- a/application/meeting.php
+++ b/application/meeting.php
@@ -188,7 +188,7 @@ if (!$userId) {
 					<a href="meeting/do_export.php?template=pdf&id=<?php echo $meeting["mee_id"]; ?>" target="_blank" class="export-link export-pdf simply-hidden">Export PDF</a>
 					<a href="meeting/do_export.php?template=markdown&id=<?php echo $meeting["mee_id"]; ?>" target="_blank" class="export-link export-markdown simply-hidden">Export Markdown</a> -->
 					<div class="row" style="margin-top:5px;">
-						<a id="btn-export-discourse" class="export-link simply-hidden btn btn-primary" href="export_discourse.php?id=<?php echo $meeting["mee_id"]; ?>" target="_blank" style="display:inline-block;">Export on Discourse <span class="glyphicon glyphicon-share"></span></a>
+						<a id="btn-export-discourse" class="export-link simply-hidden btn btn-primary" href="export_discourse.php?id=<?php echo $meeting["mee_id"]; ?>" target="_blank" style="display:inline-block;"><?php echo lang("export_discourse"); ?> <span class="glyphicon glyphicon-share"></span></a>
 					</div>
 				</div>
 			</div>

--- a/application/meeting.php
+++ b/application/meeting.php
@@ -188,7 +188,7 @@ if (!$userId) {
 					<a href="meeting/do_export.php?template=pdf&id=<?php echo $meeting["mee_id"]; ?>" target="_blank" class="export-link export-pdf simply-hidden">Export PDF</a>
 					<a href="meeting/do_export.php?template=markdown&id=<?php echo $meeting["mee_id"]; ?>" target="_blank" class="export-link export-markdown simply-hidden">Export Markdown</a> -->
 					<div class="row" style="margin-top:5px;">
-						<a class="export-link simply-hidden btn btn-primary" href="export_discourse.php?id=<?php echo $meeting["mee_id"]; ?>" target="_blank" style="display:inline-block;">Export on Discourse <span class="glyphicon glyphicon-share"></span></a>
+						<a id="btn-export-discourse" class="export-link simply-hidden btn btn-primary" href="export_discourse.php?id=<?php echo $meeting["mee_id"]; ?>" target="_blank" style="display:inline-block;">Export on Discourse <span class="glyphicon glyphicon-share"></span></a>
 					</div>
 				</div>
 			</div>

--- a/application/meeting/do_discourseCr.php
+++ b/application/meeting/do_discourseCr.php
@@ -37,14 +37,11 @@ if (!$meeting) {
 	exit();
 }
 
-$meeting[$_REQUEST["property"]] = $_REQUEST["text"];
+$discourse_category = $_REQUEST["discourse_category"];
+$discourse_title = $_REQUEST["discourse_title"];
 
+$report = file_get_contents($config["server"]["base"]. "meeting/do_export.php?template=discourse&id=" . $_REQUEST["meetingId"]);
 
-$category = $discourseApi->getCategory("sandbox"); // TODO: Choose the right category/sub-category
-$categoryId = $category->apiresult->topic_list->topics[0]->category_id;
-
-$report = file_get_contents($config["server"]["base"]. "meeting/do_export.php?template=markdown&id=" . $_REQUEST["meetingId"]);
-
-$new_topic = $discourseApi->createTopic($meeting["mee_label"] . " - " . $meeting["mee_start_time"], $report , $categoryId, $config["discourse"]["user"], $replyToId = 0);
+$new_topic = $discourseApi->createTopic($discourse_title, $report , $discourse_category, $config["discourse"]["user"], $replyToId = 0);
 
 ?>

--- a/application/meeting/do_discoursePost.php
+++ b/application/meeting/do_discoursePost.php
@@ -42,18 +42,18 @@ $userId = SessionUtils::getUserId($_SESSION);
 if (!isset($userId)) {?>
 	<div class="container">
 		<div class="jumbotron alert-danger col-xs-12">
-			<h2>Please Login</h2>
-			<p>Guests are not allowed to use this function</p>
-			<p><a class='btn btn-danger btn-lg' href='login.php' role='button'>Login</a></p>
+			<h2><?php echo lang("export_login_ask"); ?></h2>
+			<p><?php echo lang("export_permission_guests"); ?></p>
+			<p><a class='btn btn-danger btn-lg' href='connect.php' role='button'><?php echo lang("login_title"); ?></a></p>
 		</div>
 	</div>
   <?php die("error : not_enough_right");
 } elseif (($userId !== $meeting["mee_president_member_id"]) AND ($userId !== $meeting["mee_secretary_member_id"])) {?>
 	<div class="container">
 		<div class="jumbotron alert-danger col-xs-12">
-			<h2>You have not enough rights</h2>
-			<p>To avoid spam, only the president and the secretary of the session can export to Discourse.</p>
-			<p><a class='btn btn-danger btn-lg' href='meeting.php?id=<?php echo $meeting["mee_id"]; ?>' role='button'>Back</a></p>
+			<h2><?php echo lang("export_permission"); ?></h2>
+			<p><?php echo lang("export_permission_description"); ?></p>
+			<p><a class='btn btn-danger btn-lg' href='meeting.php?id=<?php echo $meeting["mee_id"]; ?>' role='button'><?php echo lang("common_back"); ?></a></p>
 		</div>
 	</div>
 	<?php die("error : not_enough_right");
@@ -62,8 +62,9 @@ if (!isset($userId)) {?>
 $discourse_category = $_REQUEST["discourse_category"];
 $discourse_title = $_REQUEST["discourse_title"];
 
+
 if (!isset($categories[$discourse_category]['id']) OR ($categories[$discourse_category]['id'] != $discourse_category)) {
-	echo "<div id='discourse-result' class='alert alert-danger' role='alert'>Unauthorized discourse category ($discourse_category)</div>";
+	echo "<div id='discourse-result' class='alert alert-danger' role='alert'>" . lang("export_permission_description") . " ($discourse_category)</div>";
 	exit("Unauthorized discourse category ($discourse_category)");
 }
 
@@ -76,8 +77,8 @@ $http_code_topic = $discourseApi->getTopic($topicId)->http_code;
 
 if ($http_code_topic=="200") {
 	$topic_url = $config["discourse"]["protocol"] . "://" . $config["discourse"]["url"] . "/t/" . $topicId;
-	echo "<div id='discourse-result' class='alert alert-success' role='alert'>The report has been published at the following adresse : <a href='$topic_url'>$topic_url</a></div>";
+	echo "<div id='discourse-result' class='alert alert-success' role='alert'>" . lang("export_discourse_success") . " <a href='$topic_url'>$topic_url</a></div>";
 } else {
-	echo "<div id='discourse-result' class='alert alert-danger' role='alert'>Error code http $http_code_topic</div>";
+	echo "<div id='discourse-result' class='alert alert-danger' role='alert'>" . lang("export_discourse_fail") . " (code http $http_code_topic)</div>";
 }
 ?>

--- a/application/meeting/export_templates/discourse.php
+++ b/application/meeting/export_templates/discourse.php
@@ -187,7 +187,7 @@ function showLevel($agendas, $level, $parent, &$voters) {
 	}
 }
 if ($textarea){
-	echo "<textarea style='width:100%;height:100%'>";
+	echo "<textarea style='width:100%;height:99%' disabled>";
 }
 ?>
 # <?php echo $meeting["mee_label"]; ?>


### PR DESCRIPTION
Une fois une réunion close le président ou le secrétaire de séance se voit proposer d'exporter le compte-rendu sur le Discourse paramétré au préalable dans les fichiers de config.

Dans config/discourse.structure.php la variable $allowed_categories est un tableau où sont définis les catégories autorisées.

Le reste de la configuration se fait dans le fichier de configuration habituel (config/config.php)

RAF : Ajouter une interface de configuration où l'on choisis les catégories autorisées (pour l'administrateur)

Pour #68 