### PR TITLE
Replace all the include_once by require_once

### DIFF
--- a/application/about.php
+++ b/application/about.php
@@ -17,7 +17,7 @@
     along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
 */
 $page = "about";
-include_once("header.php");
+require_once("header.php");
 ?>
 <div class="container theme-showcase" role="main">
 	<ol class="breadcrumb">

--- a/application/administration.php
+++ b/application/administration.php
@@ -20,13 +20,13 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-@include_once("config/config.php");
-@include_once("config/mail.config.php");
-@include_once("config/discourse.config.php");
-@include_once("config/mediawiki.config.php");
+require_once("config/config.php");
+require_once("config/mail.config.php");
+require_once("config/discourse.config.php");
+require_once("config/mediawiki.config.php");
 
-include_once("header.php");
-include_once("config/discourse.structure.php");
+require_once("header.php");
+require_once("config/discourse.structure.php");
 
 ?>
 

--- a/application/batch/import_proposition.php
+++ b/application/batch/import_proposition.php
@@ -3,7 +3,7 @@
 $path = "../";
 set_include_path(get_include_path() . PATH_SEPARATOR . $path);
 
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/bo/MotionBo.php");
 require_once("engine/bo/AgendaBo.php");
 

--- a/application/config/database.php
+++ b/application/config/database.php
@@ -16,27 +16,27 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-@include_once("config/config.php");
-@include_once("config/modules.config.php");
-@include_once("config/salt.php");
-@include_once("engine/bo/BoHelper.php");
-@include_once("engine/requests/sql/QueryFactory.php");
-@include_once("engine/requests/sql/MySQLQuery.php");
+require_once("config/config.php");
+require_once("config/modules.config.php");
+require_once("config/salt.php");
+require_once("engine/bo/BoHelper.php");
+require_once("engine/requests/sql/QueryFactory.php");
+require_once("engine/requests/sql/MySQLQuery.php");
 
-@include_once("engine/modules/usersource/UserSourceFactory.php");
-@include_once("engine/modules/usersource/GaletteUserSource.php");
-@include_once("engine/modules/usersource/CustomUserSource.php");
+require_once("engine/modules/usersource/UserSourceFactory.php");
+require_once("engine/modules/usersource/GaletteUserSource.php");
+require_once("engine/modules/usersource/CustomUserSource.php");
 
-@include_once("engine/modules/groupsource/GroupSourceFactory.php");
-@include_once("engine/modules/groupsource/GaletteGroupSource.php");
-@include_once("engine/modules/groupsource/GaletteAllMembersGroupSource.php");
-@include_once("engine/modules/groupsource/PersonaeGroupSource.php");
-@include_once("engine/modules/groupsource/PersonaeThemeSource.php");
-@include_once("engine/modules/groupsource/CustomGroupSource.php");
+require_once("engine/modules/groupsource/GroupSourceFactory.php");
+require_once("engine/modules/groupsource/GaletteGroupSource.php");
+require_once("engine/modules/groupsource/GaletteAllMembersGroupSource.php");
+require_once("engine/modules/groupsource/PersonaeGroupSource.php");
+require_once("engine/modules/groupsource/PersonaeThemeSource.php");
+require_once("engine/modules/groupsource/CustomGroupSource.php");
 
-@require_once("engine/authenticators/AuthenticatorFactory.php");
-@require_once("engine/authenticators/GaletteAuthenticator.php");
-@require_once("engine/authenticators/CustomAuthenticator.php");
+require_once("engine/authenticators/AuthenticatorFactory.php");
+require_once("engine/authenticators/GaletteAuthenticator.php");
+require_once("engine/authenticators/CustomAuthenticator.php");
 
 function openConnection($dbname = null) {
 	global $config;

--- a/application/config/mail.php
+++ b/application/config/mail.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
 */
-@include_once("config/mail.config.php");
+require_once("config/mail.config.php");
 require_once("engine/utils/PHPMailerAutoload.php");
 
 function getMailInstance() {

--- a/application/config/mediawiki.php
+++ b/application/config/mediawiki.php
@@ -17,8 +17,8 @@
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-@include_once("config/mediawiki.config.php");
-@include_once("engine/mediawiki/autoload.php");
+require_once("config/mediawiki.config.php");
+require_once("engine/mediawiki/autoload.php");
 
 function openWikiSession() {
     global $config;

--- a/application/config/memcache.php
+++ b/application/config/memcache.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-@include_once("config/config.php");
+require_once("config/config.php");
 
 function openMemcacheConnection($host = null, $port = null)
 {

--- a/application/connect.php
+++ b/application/connect.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Personae.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 require_once("engine/utils/SessionUtils.php");
 
 ?>

--- a/application/connect.php
+++ b/application/connect.php
@@ -91,7 +91,7 @@ if (isset($_GET["error"])) {
 				<div class="col-md-12 text-center">
 					<button id="connectButton" name="connectButton" class="btn btn-primary"><?php echo lang("common_connect"); ?></button>
 					
-<?php 	if ($config["modules"]["authenticator"] == "Galette") { ?>					
+<?php 	if (isset($config["modules"]["authenticator"]) && $config["modules"]["authenticator"] == "Galette") { ?>					
 					<p class="help-block"><a href="https://gestion.partipirate.org/lostpasswd.php"><?php echo lang("forgotten_link");?></a></p>
 <?php 	} 
 		else { ?>					

--- a/application/construction.php
+++ b/application/construction.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/GuestBo.php");
 require_once("engine/bo/AgendaBo.php");

--- a/application/construction_motion.php
+++ b/application/construction_motion.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/GuestBo.php");
 require_once("engine/bo/AgendaBo.php");

--- a/application/createMeeting.php
+++ b/application/createMeeting.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 include("config/mumble.structure.php");
 include("config/discord.structure.php");
 

--- a/application/decisions.php
+++ b/application/decisions.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/GuestBo.php");
 require_once("engine/bo/SearchBo.php");

--- a/application/do_downloadCalendar.php
+++ b/application/do_downloadCalendar.php
@@ -17,7 +17,7 @@
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 session_start();
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/IcsFormatter.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
@@ -59,7 +59,7 @@ foreach($meetings as $meeting) {
 			$summary .= " (" . $meeting["loc_extra"] . ")";
 		}
 		else if (($meeting["loc_type"] == "discord") AND ($meeting["loc_channel"] !== "")) {
-			include_once("config/discord.structure.php");
+			require_once("config/discord.structure.php");
 
 			list($discord_text_channel, $discord_vocal_channel) = explode(",", $meeting["loc_channel"]);
 			

--- a/application/do_forgotten.php
+++ b/application/do_forgotten.php
@@ -17,9 +17,9 @@
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 session_start();
-include_once("config/database.php");
-include_once("config/mail.php");
-include_once("language/language.php");
+require_once("config/database.php");
+require_once("config/mail.php");
+require_once("language/language.php");
 require_once("engine/utils/FormUtils.php");
 require_once("engine/utils/SessionUtils.php");
 

--- a/application/do_getMeetings.php
+++ b/application/do_getMeetings.php
@@ -21,7 +21,7 @@ ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
 session_start();
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("language/language.php");
@@ -107,7 +107,7 @@ foreach($meetings as $meeting) {
 			$event["location"]["extra"] = $meeting["loc_extra"];
 		}
 		else if (($meeting["loc_type"] == "discord") AND ($meeting["loc_channel"] !== "")) {
-			include_once("config/discord.structure.php");
+			require_once("config/discord.structure.php");
 
 			list($discord_text_channel, $discord_vocal_channel) = explode(",", $meeting["loc_channel"]);
 

--- a/application/do_login.php
+++ b/application/do_login.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/FormUtils.php");
 require_once("engine/utils/LogUtils.php");
 require_once("engine/bo/GaletteBo.php");

--- a/application/do_mypreferences.php
+++ b/application/do_mypreferences.php
@@ -17,7 +17,7 @@
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 session_start();
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/GaletteBo.php");
 require_once("engine/bo/UserBo.php");

--- a/application/do_paperVote.php
+++ b/application/do_paperVote.php
@@ -19,12 +19,12 @@
 
 session_start();
 
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/bo/MotionBo.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/qr/phpqrcode.php");
 require_once("language/language.php");
-include_once("mpdf/mpdf.php");
+require_once("mpdf/mpdf.php");
 
 $connection = openConnection();
 

--- a/application/do_sso.php
+++ b/application/do_sso.php
@@ -20,7 +20,7 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/FormUtils.php");
 require_once("engine/bo/GaletteBo.php");
 require_once("engine/authenticators/GaletteAuthenticator.php");

--- a/application/engine/utils/LogUtils.php
+++ b/application/engine/utils/LogUtils.php
@@ -1,7 +1,7 @@
 <?php
 
-@include_once("engine/bo/LogBo.php");
-@include_once("engine/utils/DateTimeUtils.php");
+require_once("engine/bo/LogBo.php");
+require_once("engine/utils/DateTimeUtils.php");
 
 function addLog($server, $session, $action = null, $data = null) {
 	

--- a/application/export.php
+++ b/application/export.php
@@ -18,11 +18,11 @@
 */
 session_start();
 
-include_once("config/database.php");
-@include_once("config/mediawiki.config.php");
-@include_once("config/discourse.config.php");
-include_once("config/database.php");
-include_once("language/language.php");
+require_once("config/database.php");
+require_once("config/mediawiki.config.php");
+require_once("config/discourse.config.php");
+require_once("config/database.php");
+require_once("language/language.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("config/config.php");
@@ -84,8 +84,8 @@ else {
 	<?php 	} ?>
 
 	<?php if ($template == "discourse") {
-			include_once("config/discourse.structure.php");
-			include_once("config/discourse.config.php");
+			require_once("config/discourse.structure.php");
+			require_once("config/discourse.config.php");
 	?>
 	    <div id="discourse_post" class="simply-hidden">
 	      <?php				if (!isset($userId)) {?>
@@ -141,7 +141,7 @@ else {
 	    </div>
 	<?php }?>
 	<?php if ($template == "markdown") {
-			include_once("config/mediawiki.config.php");
+			require_once("config/mediawiki.config.php");
 	?>
 	    <div id="wiki_post" class="simply-hidden">
 	      <?php				if (!isset($userId)) {?>

--- a/application/forgotten.php
+++ b/application/forgotten.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 require_once("engine/utils/SessionUtils.php");
 
 ?>

--- a/application/groupMeetings.php
+++ b/application/groupMeetings.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/GuestBo.php");

--- a/application/header.php
+++ b/application/header.php
@@ -22,19 +22,19 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-include_once("install/Installer.php");
+require_once("install/Installer.php");
 
-include_once("config/database.php");
-include_once("language/language.php");
+require_once("config/database.php");
+require_once("language/language.php");
 require_once("engine/bo/GaletteBo.php");
 require_once("engine/bo/UserPropertyBo.php");
 require_once("engine/bo/MeetingBo.php");
 
-include_once("engine/utils/bootstrap_forms.php");
+require_once("engine/utils/bootstrap_forms.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/utils/FormUtils.php");
-include_once("engine/utils/LogUtils.php");
-include_once("engine/utils/DateTimeUtils.php");
+require_once("engine/utils/LogUtils.php");
+require_once("engine/utils/DateTimeUtils.php");
 
 require_once("engine/utils/GamifierClient.php");
 

--- a/application/index.php
+++ b/application/index.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/MotionBo.php");
 require_once("engine/utils/Parsedown.php");

--- a/application/install/Installer.php
+++ b/application/install/Installer.php
@@ -23,7 +23,7 @@ if (!file_exists("config/config.php")) {
     // Create config files
     $_SESSION["administrator"] = true;
     $_REQUEST["api"] = false;
-    include_once("do_updateAdministration.php");
+    require_once("do_updateAdministration.php");
 
     // switch to administration mode
 	header('Location: administration.php');

--- a/application/language/language.php
+++ b/application/language/language.php
@@ -56,7 +56,7 @@ function isLanguageKey($key, $language = null, $path = "") {
 		$directoryHandler = dir($path. "language/" . $language);
 		while(($fileEntry = $directoryHandler->read()) !== false) {
 			if($fileEntry != '.' && $fileEntry != '..' && strpos($fileEntry, ".php")) {
-				include_once("language/" . $language . "/" . $fileEntry);
+				require_once("language/" . $language . "/" . $fileEntry);
 			}
 		}
 		$directoryHandler->close();

--- a/application/meeting.php
+++ b/application/meeting.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/GuestBo.php");
 require_once("engine/utils/bootstrap_forms.php");

--- a/application/meeting/do_addAgendaPoint.php
+++ b/application/meeting/do_addAgendaPoint.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_addChat.php
+++ b/application/meeting/do_addChat.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_addCoAuthor.php
+++ b/application/meeting/do_addCoAuthor.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/CoAuthorBo.php");

--- a/application/meeting/do_addConclusion.php
+++ b/application/meeting/do_addConclusion.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ConclusionBo.php");

--- a/application/meeting/do_addConstruction.php
+++ b/application/meeting/do_addConstruction.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_addMotion.php
+++ b/application/meeting/do_addMotion.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_addMotionProposition.php
+++ b/application/meeting/do_addMotionProposition.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_addNotice.php
+++ b/application/meeting/do_addNotice.php
@@ -19,7 +19,7 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/NoticeBo.php");

--- a/application/meeting/do_addSource.php
+++ b/application/meeting/do_addSource.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_addTask.php
+++ b/application/meeting/do_addTask.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/TaskBo.php");

--- a/application/meeting/do_changeAgendaPoint.php
+++ b/application/meeting/do_changeAgendaPoint.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_changeChat.php
+++ b/application/meeting/do_changeChat.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_changeConclusion.php
+++ b/application/meeting/do_changeConclusion.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ConclusionBo.php");

--- a/application/meeting/do_changeGuest.php
+++ b/application/meeting/do_changeGuest.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/PingBo.php");

--- a/application/meeting/do_changeMeeting.php
+++ b/application/meeting/do_changeMeeting.php
@@ -19,7 +19,7 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/utils/DateTimeUtils.php");

--- a/application/meeting/do_changeMotionProperty.php
+++ b/application/meeting/do_changeMotionProperty.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MotionBo.php");
 

--- a/application/meeting/do_changeMotionStatus.php
+++ b/application/meeting/do_changeMotionStatus.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_changeNotice.php
+++ b/application/meeting/do_changeNotice.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/NoticeBo.php");

--- a/application/meeting/do_changeOfficeMember.php
+++ b/application/meeting/do_changeOfficeMember.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 

--- a/application/meeting/do_changeRights.php
+++ b/application/meeting/do_changeRights.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/MeetingRightBo.php");

--- a/application/meeting/do_changeTask.php
+++ b/application/meeting/do_changeTask.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/TaskBo.php");

--- a/application/meeting/do_computeVote.new.php
+++ b/application/meeting/do_computeVote.new.php
@@ -22,8 +22,8 @@ session_start();
 $path = "../";
 set_include_path(get_include_path() . PATH_SEPARATOR . $path);
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/GaletteBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_computeVote.php
+++ b/application/meeting/do_computeVote.php
@@ -22,7 +22,7 @@
 $path = "../";
 set_include_path(get_include_path() . PATH_SEPARATOR . $path);
 
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MotionBo.php");
 require_once("engine/bo/VoteBo.php");

--- a/application/meeting/do_createMeeting.php
+++ b/application/meeting/do_createMeeting.php
@@ -22,7 +22,7 @@ session_start();
 $path = "../";
 set_include_path(get_include_path() . PATH_SEPARATOR . $path);
 
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/LocationBo.php");
 require_once("engine/bo/AgendaBo.php");

--- a/application/meeting/do_discoursePost.php
+++ b/application/meeting/do_discoursePost.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/discourse.config.php");
-include_once("config/discourse.structure.php");
+require_once("config/discourse.config.php");
+require_once("config/discourse.structure.php");
 require_once("engine/discourse/DiscourseAPI.php");
 $discourseApi = new richp10\discourseAPI\DiscourseAPI($config["discourse"]["url"], $config["discourse"]["api_key"], $config["discourse"]["protocol"]);
 

--- a/application/meeting/do_exchangeAuthors.php
+++ b/application/meeting/do_exchangeAuthors.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/CoAuthorBo.php");
 require_once("engine/bo/MotionBo.php");

--- a/application/meeting/do_export.php
+++ b/application/meeting/do_export.php
@@ -26,7 +26,7 @@ ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);
 
-include_once("config/database.php");
+require_once("config/database.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/AgendaBo.php");
@@ -230,7 +230,7 @@ foreach($pings as $ping) {
 
 ob_start();
 
-include_once("meeting/export_templates/$template.php");
+require_once("meeting/export_templates/$template.php");
 
 $content = ob_get_contents();
 
@@ -239,7 +239,7 @@ ob_end_clean();
 // Post-process the computation
 
 if (file_exists("export_templates/" . $template . "_post.php")) {
-	include_once("meeting/export_templates/" . $template . "_post.php");
+	require_once("meeting/export_templates/" . $template . "_post.php");
 }
 
 echo $content;

--- a/application/meeting/do_externalChat.php
+++ b/application/meeting/do_externalChat.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/PingBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_finishTask.php
+++ b/application/meeting/do_finishTask.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/TaskBo.php");

--- a/application/meeting/do_getAgenda.php
+++ b/application/meeting/do_getAgenda.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/MeetingRightBo.php");

--- a/application/meeting/do_getAgendaPoint.php
+++ b/application/meeting/do_getAgendaPoint.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_getEvents.php
+++ b/application/meeting/do_getEvents.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/config.php");
-include_once("config/memcache.php");
+require_once("config/config.php");
+require_once("config/memcache.php");
 require_once("engine/utils/EventStackUtils.php");
 
 $meetingId = $arguments["meetingId"];

--- a/application/meeting/do_getMeetings.php
+++ b/application/meeting/do_getMeetings.php
@@ -19,11 +19,11 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
-include_once("config/memcache.php");
+require_once("config/memcache.php");
 //require_once("engine/bo/MeetingRightBo.php");
 //require_once("engine/bo/AgendaBo.php");
 

--- a/application/meeting/do_getPeople.php
+++ b/application/meeting/do_getPeople.php
@@ -22,8 +22,8 @@ if (!isset($api)) exit();
 define("CONNECTED_TIME", 60);
 define("DISCONNECTED_TIME", 65);
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/utils/EventStackUtils.php");
 require_once("engine/utils/DateTimeUtils.php");

--- a/application/meeting/do_getTasks.php
+++ b/application/meeting/do_getTasks.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/config.php");
-include_once("config/memcache.php");
+require_once("config/config.php");
+require_once("config/memcache.php");
 require_once("engine/utils/EventStackUtils.php");
 
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_openDebate.php
+++ b/application/meeting/do_openDebate.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/discourse.config.php");
-include_once("config/discourse.structure.php");
+require_once("config/discourse.config.php");
+require_once("config/discourse.structure.php");
 require_once("engine/discourse/DiscourseAPI.php");
 
 require_once("engine/bo/GaletteBo.php");

--- a/application/meeting/do_ping.php
+++ b/application/meeting/do_ping.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/PingBo.php");

--- a/application/meeting/do_removeAgendaPoint.php
+++ b/application/meeting/do_removeAgendaPoint.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_removeChat.php
+++ b/application/meeting/do_removeChat.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_removeCoAuthor.php
+++ b/application/meeting/do_removeCoAuthor.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/CoAuthorBo.php");
 

--- a/application/meeting/do_removeConclusion.php
+++ b/application/meeting/do_removeConclusion.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_removeMotion.php
+++ b/application/meeting/do_removeMotion.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_removeMotionProposition.php
+++ b/application/meeting/do_removeMotionProposition.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/ChatBo.php");

--- a/application/meeting/do_removeNotice.php
+++ b/application/meeting/do_removeNotice.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/NoticeBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_removeSpeaker.php
+++ b/application/meeting/do_removeSpeaker.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/PingBo.php");

--- a/application/meeting/do_removeTask.php
+++ b/application/meeting/do_removeTask.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_requestSpeaking.php
+++ b/application/meeting/do_requestSpeaking.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/PingBo.php");

--- a/application/meeting/do_setSpeaking.php
+++ b/application/meeting/do_setSpeaking.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/PingBo.php");

--- a/application/meeting/do_trashMotion.php
+++ b/application/meeting/do_trashMotion.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/AgendaBo.php");
 require_once("engine/bo/MeetingBo.php");

--- a/application/meeting/do_vote.php
+++ b/application/meeting/do_vote.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MotionBo.php");
 require_once("engine/bo/VoteBo.php");

--- a/application/meeting/do_voteConstruction.php
+++ b/application/meeting/do_voteConstruction.php
@@ -19,8 +19,8 @@
 
 if (!isset($api)) exit();
 
-include_once("config/database.php");
-include_once("config/memcache.php");
+require_once("config/database.php");
+require_once("config/memcache.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/bo/MotionBo.php");
 require_once("engine/bo/VoteBo.php");

--- a/application/meeting_api.php
+++ b/application/meeting_api.php
@@ -24,9 +24,9 @@ error_reporting(E_ALL);
 header("Access-Control-Allow-Origin: *");
  
 require_once("config/database.php");
-include_once("config/memcache.php");
-include_once("config/mail.php");
-include_once("language/language.php");
+require_once("config/memcache.php");
+require_once("config/mail.php");
+require_once("language/language.php");
 require_once("engine/utils/SessionUtils.php");
 require_once("engine/utils/FormUtils.php");
 require_once("engine/utils/GamifierClient.php");

--- a/application/mpdf/classes/indic.php
+++ b/application/mpdf/classes/indic.php
@@ -11,7 +11,7 @@ function substituteIndic($earr, $lang, $font) {
 	global $voltdata;
 
 	if (!isset($voltdata[$font])) {
-		include_once(_MPDF_PATH.'includes/'.$font.'.volt.php');
+		require_once(_MPDF_PATH.'includes/'.$font.'.volt.php');
 		$voltdata[$font] = $volt;
 	}
 

--- a/application/mpdf/graph.php
+++ b/application/mpdf/graph.php
@@ -21,15 +21,15 @@ $JpgUseSVGFormat = true;
 //==============================================================================================================
 // LOAD GRAPHS
 
-	include_once(_JPGRAPH_PATH.'jpgraph.php'); 
-	include_once(_JPGRAPH_PATH.'jpgraph_line.php' ); 
-	include_once(_JPGRAPH_PATH.'jpgraph_log.php' ); 
-	include_once(_JPGRAPH_PATH.'jpgraph_scatter.php' ); 
-	include_once(_JPGRAPH_PATH.'jpgraph_regstat.php' ); 
-	include_once(_JPGRAPH_PATH.'jpgraph_pie.php'); 
-	include_once(_JPGRAPH_PATH.'jpgraph_pie3d.php'); 
-	include_once(_JPGRAPH_PATH.'jpgraph_bar.php'); 
-	include_once(_JPGRAPH_PATH.'jpgraph_radar.php'); 
+	require_once(_JPGRAPH_PATH.'jpgraph.php'); 
+	require_once(_JPGRAPH_PATH.'jpgraph_line.php' ); 
+	require_once(_JPGRAPH_PATH.'jpgraph_log.php' ); 
+	require_once(_JPGRAPH_PATH.'jpgraph_scatter.php' ); 
+	require_once(_JPGRAPH_PATH.'jpgraph_regstat.php' ); 
+	require_once(_JPGRAPH_PATH.'jpgraph_pie.php'); 
+	require_once(_JPGRAPH_PATH.'jpgraph_pie3d.php'); 
+	require_once(_JPGRAPH_PATH.'jpgraph_bar.php'); 
+	require_once(_JPGRAPH_PATH.'jpgraph_radar.php'); 
 
 
 //======================================================================================================

--- a/application/mpdf/mpdf.php
+++ b/application/mpdf/mpdf.php
@@ -10342,7 +10342,7 @@ function _getImage(&$file, $firsttime=true, $allowvector=true, $orig_srcpath=fal
 		}
 
 		if (!class_exists('gif', false)) { 
-			include_once(_MPDF_PATH.'classes/gif.php'); 
+			require_once(_MPDF_PATH.'classes/gif.php'); 
 		}
 		$gif=new CGIF();
 
@@ -16917,7 +16917,7 @@ function OpenTag($tag,$attr)
 	if ($attr['TABLE']) { $gid = strtoupper($attr['TABLE']); }
 	else { $gid = '0'; }
 	if (!is_array($this->graphs[$gid]) || count($this->graphs[$gid])==0 ) { break; }
-	include_once(_MPDF_PATH.'graph.php');
+	require_once(_MPDF_PATH.'graph.php');
 	$this->graphs[$gid]['attr'] = $attr;
 
 

--- a/application/mpdf/mpdfi/fpdi_pdf_parser.php
+++ b/application/mpdf/mpdfi/fpdi_pdf_parser.php
@@ -226,13 +226,13 @@ class fpdi_pdf_parser extends pdf_parser {
                 break;
 			// mPDF 4.2.003
                 case '/LZWDecode': 
-			include_once(_MPDF_PATH.'mpdfi/filters/FilterLZW.php');
+			require_once(_MPDF_PATH.'mpdfi/filters/FilterLZW.php');
 			// mPDF 5.0 Removed pass by reference =&
 			$decoder = new FilterLZW();
 			$stream = $decoder->decode($stream);
 			break;
                 case '/ASCII85Decode':
-			include_once(_MPDF_PATH.'mpdfi/filters/FilterASCII85.php');
+			require_once(_MPDF_PATH.'mpdfi/filters/FilterASCII85.php');
 			// mPDF 5.0 Removed pass by reference =&
 			$decoder = new FilterASCII85();
 			$stream = $decoder->decode($stream);

--- a/application/myBadges.php
+++ b/application/myBadges.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 $badges = $gamifierClient->getBadges($config["gamifier"]["service_uuid"], $config["gamifier"]["service_secret"]);
 $notices = array();

--- a/application/myMeetings.php
+++ b/application/myMeetings.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/MeetingBo.php");
 require_once("engine/bo/NoticeBo.php");

--- a/application/myVotes.php
+++ b/application/myVotes.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/MotionBo.php");
 

--- a/application/mypreferences.php
+++ b/application/mypreferences.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 require_once("engine/utils/SessionUtils.php");
 
 ?>

--- a/application/notice.php
+++ b/application/notice.php
@@ -19,7 +19,7 @@
 
 require_once("config/database.php");
 require_once("engine/utils/SessionUtils.php");
-include_once("language/language.php");
+require_once("language/language.php");
 
 $connection = openConnection();
 

--- a/application/page.php
+++ b/application/page.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Personae.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 
 ?>

--- a/application/search.php
+++ b/application/search.php
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
-include_once("header.php");
+require_once("header.php");
 
 require_once("engine/bo/SearchBo.php");
 


### PR DESCRIPTION
Hi,

May I propose to change all the **include_once** into **require_once**? (as if a file is not found it should raise an error and stop. Using include, the application is trying to go further and might become unstable.)

I also remove all the **@** sign in front of the **require_once** as it hide error. Errors should NEVER be hidden but handled.

And finally I add a check in the **connect.php** file (line 94) as the variable is not set by default.