### PR TITLE
update copyright notice: OpenTweetBar to Congressus, add 2019, etc.

### DIFF
--- a/application/BreadcrumbHandler.php
+++ b/application/BreadcrumbHandler.php
@@ -1,26 +1,26 @@
 <?php /*
-	Copyright 2018-2019 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function getBreadcrumb() {
     $crumbs = array();
     $currentPage = basename($_SERVER["SCRIPT_FILENAME"]);
-    
+
     $indexCrumb = array("isActive" => ($currentPage == "index.php"), "links" => array("index.php"), "labels" => array(lang("breadcrumb_index")));
     $crumbs[] = $indexCrumb;
 

--- a/application/CardHandler.php
+++ b/application/CardHandler.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 $current_url = $config["server"]["base"] . $_SERVER["REQUEST_URI"];

--- a/application/about.php
+++ b/application/about.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2014-2015 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 $page = "about";
 include_once("header.php");

--- a/application/activate.php
+++ b/application/activate.php
@@ -1,20 +1,21 @@
-<?php /*
-	Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+<?php /*/*
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
+*/
 */
 $page = "activate";
 include_once("header.php");

--- a/application/administration.php
+++ b/application/administration.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/administration/do_createDatabase.php
+++ b/application/administration/do_createDatabase.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/administration/do_deployDatabase.php
+++ b/application/administration/do_deployDatabase.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 function tableExists($pdo, $table) {
@@ -35,8 +35,8 @@ function createTable($pdo, $table, $structure) {
 	foreach($structure["fields"] as $fieldName => $fieldStructure) {
 		$query .= $separator;
 
-		$query .= "`$fieldName` "; 
-		$query .= $fieldStructure["type"]; 
+		$query .= "`$fieldName` ";
+		$query .= $fieldStructure["type"];
 
 		if (isset($fieldStructure["size"])) {
 			$query .= " (" . $fieldStructure["size"] . ")";

--- a/application/administration/do_pingDatabase.php
+++ b/application/administration/do_pingDatabase.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/administration/do_pingMemcached.php
+++ b/application/administration/do_pingMemcached.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/administration/do_testMail.php
+++ b/application/administration/do_testMail.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/administration_api.php
+++ b/application/administration_api.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/css/flags.css
+++ b/application/assets/css/flags.css
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 @CHARSET "UTF-8";
 

--- a/application/assets/css/fonts.css
+++ b/application/assets/css/fonts.css
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with PPMoney.  If not, see <http://www.gnu.org/licenses/>.
+    along with PPMoney.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 @font-face {

--- a/application/assets/css/index.html
+++ b/application/assets/css/index.html
@@ -1,20 +1,20 @@
 <!--
-    Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <html>
 <head>

--- a/application/assets/css/jquery.template.css
+++ b/application/assets/css/jquery.template.css
@@ -1,20 +1,20 @@
 /*
-    Copyright 2014-2015 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 templates, .template {
 	display: none;

--- a/application/assets/css/opentweetbar.css
+++ b/application/assets/css/opentweetbar.css
@@ -1,20 +1,21 @@
-/*
-    Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+/*/*
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
+*/
 */
 html,body {
 	height: 100%;

--- a/application/assets/css/style.css
+++ b/application/assets/css/style.css
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 @font-face {

--- a/application/assets/js/autogrow.js
+++ b/application/assets/js/autogrow.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018-2019 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/emojione.helper.js
+++ b/application/assets/js/emojione.helper.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global jQuery */

--- a/application/assets/js/index.html
+++ b/application/assets/js/index.html
@@ -1,20 +1,20 @@
 <!--
-    Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <html>
 <head>

--- a/application/assets/js/jquery.template.js
+++ b/application/assets/js/jquery.template.js
@@ -1,20 +1,20 @@
 /*
-    Copyright 2014-2015 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function replaceData(string, data) {

--- a/application/assets/js/merger.js
+++ b/application/assets/js/merger.js
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global stringDiff */

--- a/application/assets/js/pad.js
+++ b/application/assets/js/pad.js
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/pagination.js
+++ b/application/assets/js/pagination.js
@@ -1,20 +1,20 @@
 /*
-    Copyright 2014-2015 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 var tweetPerPage = 5;

--- a/application/assets/js/perpage/administration.js
+++ b/application/assets/js/perpage/administration.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 

--- a/application/assets/js/perpage/construction.js
+++ b/application/assets/js/perpage/construction.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/construction_motion.js
+++ b/application/assets/js/perpage/construction_motion.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/construction_motion_authorship.js
+++ b/application/assets/js/perpage/construction_motion_authorship.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/construction_motion_save.js
+++ b/application/assets/js/perpage/construction_motion_save.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/construction_source_helper.js
+++ b/application/assets/js/perpage/construction_source_helper.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/construction_source_save.js
+++ b/application/assets/js/perpage/construction_source_save.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/createMeeting.js
+++ b/application/assets/js/perpage/createMeeting.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 /* global moment */

--- a/application/assets/js/perpage/export.js
+++ b/application/assets/js/perpage/export.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2017 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
+    Copyright 2017 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/forgotten.js
+++ b/application/assets/js/perpage/forgotten.js
@@ -1,20 +1,20 @@
 /*
-    Copyright 2014-2015 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function forgottenResponseHandler(data) {

--- a/application/assets/js/perpage/groups.js
+++ b/application/assets/js/perpage/groups.js
@@ -1,20 +1,20 @@
 /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/location_form.js
+++ b/application/assets/js/perpage/location_form.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 /* global hasWritingRight */

--- a/application/assets/js/perpage/meeting.js
+++ b/application/assets/js/perpage/meeting.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 /* global testBadges */

--- a/application/assets/js/perpage/meeting_agenda.js
+++ b/application/assets/js/perpage/meeting_agenda.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/js/perpage/meeting_charts.js
+++ b/application/assets/js/perpage/meeting_charts.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/js/perpage/meeting_events.js
+++ b/application/assets/js/perpage/meeting_events.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/js/perpage/meeting_export.js
+++ b/application/assets/js/perpage/meeting_export.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2017 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
+    Copyright 2017 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/js/perpage/meeting_motion.js
+++ b/application/assets/js/perpage/meeting_motion.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/js/perpage/meeting_people.js
+++ b/application/assets/js/perpage/meeting_people.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/js/perpage/meeting_time.js
+++ b/application/assets/js/perpage/meeting_time.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/js/perpage/meeting_timer.js
+++ b/application/assets/js/perpage/meeting_timer.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/assets/js/perpage/myMeetings.js
+++ b/application/assets/js/perpage/myMeetings.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 

--- a/application/assets/js/perpage/myVotes.js
+++ b/application/assets/js/perpage/myVotes.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 /* global judgementMajorityValues */

--- a/application/assets/js/perpage/mypreferences.js
+++ b/application/assets/js/perpage/mypreferences.js
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/order_list_helper.js
+++ b/application/assets/js/perpage/order_list_helper.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/register.js
+++ b/application/assets/js/perpage/register.js
@@ -1,20 +1,20 @@
 /*
-    Copyright 2014-2015 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 var timers = {};

--- a/application/assets/js/perpage/search.js
+++ b/application/assets/js/perpage/search.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 /* global query */

--- a/application/assets/js/perpage/theme.js
+++ b/application/assets/js/perpage/theme.js
@@ -1,20 +1,20 @@
 /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/perpage/theme_user_delegation_advanced.js
+++ b/application/assets/js/perpage/theme_user_delegation_advanced.js
@@ -1,20 +1,20 @@
 /*
-	Copyright 2018-2019 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+	This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/search.js
+++ b/application/assets/js/search.js
@@ -1,20 +1,20 @@
 /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+	This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/assets/js/social.js
+++ b/application/assets/js/social.js
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 

--- a/application/assets/js/user.js
+++ b/application/assets/js/user.js
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /* global $ */
 /* global gamifiedUser */

--- a/application/assets/js/window.js
+++ b/application/assets/js/window.js
@@ -1,7 +1,7 @@
 /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /* global $ */

--- a/application/ballots/index.html
+++ b/application/ballots/index.html
@@ -1,20 +1,20 @@
 <!--
-    Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <html>
 <head>

--- a/application/calendar.php
+++ b/application/calendar.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/config/database.php
+++ b/application/config/database.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/application/config/discord.structure.sample.php
+++ b/application/config/discord.structure.sample.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2017-2018 Parti Pirate
+    Copyright 2017-2018 Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $config["discord"]["usable"] = false; // set to true to enable discord chat room

--- a/application/config/discourse.structure.php
+++ b/application/config/discourse.structure.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2017 Nino Treyssat-Vincent, Parti Pirate
+    Copyright 2017 Nino Treyssat-Vincent, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 require_once("discourse.config.php");
 require_once("engine/discourse/DiscourseAPI.php");

--- a/application/config/mail.php
+++ b/application/config/mail.php
@@ -1,20 +1,21 @@
-<?php /*
-	Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+<?php /*/*
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
+*/
 */
 @include_once("config/mail.config.php");
 require_once("engine/utils/PHPMailerAutoload.php");

--- a/application/config/mediawiki.config.sample.php
+++ b/application/config/mediawiki.config.sample.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if(!isset($config)) {

--- a/application/config/mediawiki.php
+++ b/application/config/mediawiki.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 @include_once("config/mediawiki.config.php");

--- a/application/config/memcache.php
+++ b/application/config/memcache.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 @include_once("config/config.php");
 

--- a/application/config/mumble.structure.php
+++ b/application/config/mumble.structure.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2017-2018 Nino Treyssat-Vincent, Parti Pirate
+    Copyright 2017-2018 Nino Treyssat-Vincent, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $config["mumble"]["usable"] = false;

--- a/application/connect.php
+++ b/application/connect.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2016 Cédric Levieux, Parti Pirate
+    Copyright 2016 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 require_once("engine/utils/SessionUtils.php");

--- a/application/construct_languages.php
+++ b/application/construct_languages.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 require_once("language/language.php");

--- a/application/construction.php
+++ b/application/construction.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/construction/pieChart.php
+++ b/application/construction/pieChart.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 // Need $voteCounters

--- a/application/construction/preview.php
+++ b/application/construction/preview.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 require_once("engine/utils/Parsedown.php");

--- a/application/construction_motion.php
+++ b/application/construction_motion.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018-2019 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/createMeeting.php
+++ b/application/createMeeting.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 include_once("config/memcache.php");

--- a/application/decisions.php
+++ b/application/decisions.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/do_candidate.php
+++ b/application/do_candidate.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+	This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_changeLanguage.php
+++ b/application/do_changeLanguage.php
@@ -1,20 +1,21 @@
-<?php /*
-	Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+<?php /*/*
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
+*/
 */
 session_start();
 require_once("engine/utils/SessionUtils.php");

--- a/application/do_delete_group.php
+++ b/application/do_delete_group.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_delete_theme.php
+++ b/application/do_delete_theme.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_downloadCalendar.php
+++ b/application/do_downloadCalendar.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2016-2017 Cédric Levieux, Parti Pirate
+    Copyright 2016-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 session_start();
 include_once("config/database.php");

--- a/application/do_exclude_theme_group.php
+++ b/application/do_exclude_theme_group.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_forgotten.php
+++ b/application/do_forgotten.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_free_enter.php
+++ b/application/do_free_enter.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /*
 ini_set('display_errors', 1);

--- a/application/do_getMeetings.php
+++ b/application/do_getMeetings.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_get_member_stats.php
+++ b/application/do_get_member_stats.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_login.php
+++ b/application/do_login.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_logout.php
+++ b/application/do_logout.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of PPMoney.
+    This file is part of PPMoney.
 
     PPMoney is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with PPMoney.  If not, see <http://www.gnu.org/licenses/>.
+    along with PPMoney.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_mypreferences.php
+++ b/application/do_mypreferences.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 session_start();
 include_once("config/database.php");

--- a/application/do_paperVote.php
+++ b/application/do_paperVote.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 session_start();

--- a/application/do_register.php
+++ b/application/do_register.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_save_advanced_delegations.php
+++ b/application/do_save_advanced_delegations.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_save_group.php
+++ b/application/do_save_group.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_save_power_theme.php
+++ b/application/do_save_power_theme.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_save_theme.php
+++ b/application/do_save_theme.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_search_member.php
+++ b/application/do_search_member.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_set_fixation_member.php
+++ b/application/do_set_fixation_member.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_set_fixation_property.php
+++ b/application/do_set_fixation_property.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_set_group_admin.php
+++ b/application/do_set_group_admin.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_set_group_authority.php
+++ b/application/do_set_group_authority.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 ini_set('display_errors', 1);

--- a/application/do_set_new_fixation_theme.php
+++ b/application/do_set_new_fixation_theme.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_set_theme_admin.php
+++ b/application/do_set_theme_admin.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/do_sso.php
+++ b/application/do_sso.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2016 Cédric Levieux, Parti Pirate
+    Copyright 2016 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_updateAdministration.php
+++ b/application/do_updateAdministration.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (session_status() == PHP_SESSION_NONE) {

--- a/application/do_userDataExist.php
+++ b/application/do_userDataExist.php
@@ -1,20 +1,21 @@
-<?php /*
-	Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+<?php /*/*
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
+*/
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/do_voting.php
+++ b/application/do_voting.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("config/database.php");
 require_once("engine/utils/FormUtils.php");

--- a/application/engine/authenticators/AuthenticatorFactory.php
+++ b/application/engine/authenticators/AuthenticatorFactory.php
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
     
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class AuthenticatorFactory {

--- a/application/engine/authenticators/CustomAuthenticator.php
+++ b/application/engine/authenticators/CustomAuthenticator.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
-	
-	This file is part of Congressus.
-	
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
+
+    This file is part of Congressus.
+
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	Congressus is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
-	
+
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class CustomAuthenticator {

--- a/application/engine/authenticators/GaletteAuthenticator.php
+++ b/application/engine/authenticators/GaletteAuthenticator.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
-	
-	This file is part of Congressus.
-	
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
+
+    This file is part of Congressus.
+
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	Congressus is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
-	
+
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GaletteAuthenticator {

--- a/application/engine/authenticators/InternalAuthenticator.php
+++ b/application/engine/authenticators/InternalAuthenticator.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
-	
-	This file is part of Congressus.
-	
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
+
+    This file is part of Congressus.
+
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	Congressus is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
-	
+
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class InternalAuthenticator {

--- a/application/engine/bo/ABo.php
+++ b/application/engine/bo/ABo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of PPMoney.
+    This file is part of PPMoney.
 
     PPMoney is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with PPMoney.  If not, see <http://www.gnu.org/licenses/>.
+    along with PPMoney.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 abstract class ABo {

--- a/application/engine/bo/AgendaBo.php
+++ b/application/engine/bo/AgendaBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class AgendaBo {

--- a/application/engine/bo/BoHelper.php
+++ b/application/engine/bo/BoHelper.php
@@ -1,7 +1,7 @@
 <?php  /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class BoHelper {

--- a/application/engine/bo/CandidateBo.php
+++ b/application/engine/bo/CandidateBo.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class CandidateBo {

--- a/application/engine/bo/ChatAdviceBo.php
+++ b/application/engine/bo/ChatAdviceBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class ChatAdviceBo {

--- a/application/engine/bo/ChatBo.php
+++ b/application/engine/bo/ChatBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class ChatBo {

--- a/application/engine/bo/CoAuthorBo.php
+++ b/application/engine/bo/CoAuthorBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class CoAuthorBo {

--- a/application/engine/bo/ConclusionBo.php
+++ b/application/engine/bo/ConclusionBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class ConclusionBo {

--- a/application/engine/bo/CustomizerBo.php
+++ b/application/engine/bo/CustomizerBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class CustomizerBo {

--- a/application/engine/bo/CustomizerPropertyBo.php
+++ b/application/engine/bo/CustomizerPropertyBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class CustomizerPropertyBo {

--- a/application/engine/bo/DelegationBo.php
+++ b/application/engine/bo/DelegationBo.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class DelegationBo {

--- a/application/engine/bo/DelegationConditionBo.php
+++ b/application/engine/bo/DelegationConditionBo.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class DelegationConditionBo {

--- a/application/engine/bo/FixationBo.php
+++ b/application/engine/bo/FixationBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class FixationBo {

--- a/application/engine/bo/GaletteBo.php
+++ b/application/engine/bo/GaletteBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of PPMoney.
+    This file is part of PPMoney.
 
     PPMoney is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with PPMoney.  If not, see <http://www.gnu.org/licenses/>.
+    along with PPMoney.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GaletteBo {

--- a/application/engine/bo/GameEvents.php
+++ b/application/engine/bo/GameEvents.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GameEvents {

--- a/application/engine/bo/GroupBo.php
+++ b/application/engine/bo/GroupBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GroupBo {

--- a/application/engine/bo/GuestBo.php
+++ b/application/engine/bo/GuestBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GuestBo {

--- a/application/engine/bo/LocationBo.php
+++ b/application/engine/bo/LocationBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class LocationBo {

--- a/application/engine/bo/LogBo.php
+++ b/application/engine/bo/LogBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class LogBo {

--- a/application/engine/bo/MeetingBo.php
+++ b/application/engine/bo/MeetingBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class MeetingBo {

--- a/application/engine/bo/MeetingRightBo.php
+++ b/application/engine/bo/MeetingRightBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class MeetingRightBo {

--- a/application/engine/bo/MotionBo.php
+++ b/application/engine/bo/MotionBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class MotionBo {

--- a/application/engine/bo/NoticeBo.php
+++ b/application/engine/bo/NoticeBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class NoticeBo {

--- a/application/engine/bo/PingBo.php
+++ b/application/engine/bo/PingBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class PingBo {

--- a/application/engine/bo/SearchBo.php
+++ b/application/engine/bo/SearchBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class SearchBo {

--- a/application/engine/bo/ServerAdminBo.php
+++ b/application/engine/bo/ServerAdminBo.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class ServerAdminBo {

--- a/application/engine/bo/SkillBo.php
+++ b/application/engine/bo/SkillBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2016 Cédric Levieux, Parti Pirate
+    Copyright 2015-2016 Cédric Levieux, Parti Pirate
 
-	This file is part of Fabrilia.
+    This file is part of Fabrilia.
 
     Fabrilia is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Fabrilia.  If age, see <http://www.gnu.org/licenses/>.
+    along with Fabrilia.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class SkillBo {

--- a/application/engine/bo/SkillEndorsmentBo.php
+++ b/application/engine/bo/SkillEndorsmentBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2016 Cédric Levieux, Parti Pirate
+    Copyright 2015-2016 Cédric Levieux, Parti Pirate
 
-	This file is part of Fabrilia.
+    This file is part of Fabrilia.
 
     Fabrilia is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Fabrilia.  If age, see <http://www.gnu.org/licenses/>.
+    along with Fabrilia.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class SkillEndorsmentBo {

--- a/application/engine/bo/SkillUserBo.php
+++ b/application/engine/bo/SkillUserBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2016 Cédric Levieux, Parti Pirate
+    Copyright 2015-2016 Cédric Levieux, Parti Pirate
 
-	This file is part of Fabrilia.
+    This file is part of Fabrilia.
 
     Fabrilia is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Fabrilia.  If age, see <http://www.gnu.org/licenses/>.
+    along with Fabrilia.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class SkillUserBo {

--- a/application/engine/bo/SourceBo.php
+++ b/application/engine/bo/SourceBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class SourceBo {

--- a/application/engine/bo/TagBo.php
+++ b/application/engine/bo/TagBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class TagBo {

--- a/application/engine/bo/TaskBo.php
+++ b/application/engine/bo/TaskBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class TaskBo {

--- a/application/engine/bo/ThemeBo.php
+++ b/application/engine/bo/ThemeBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class ThemeBo {

--- a/application/engine/bo/UserBo.php
+++ b/application/engine/bo/UserBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class UserBo {

--- a/application/engine/bo/UserPropertyBo.php
+++ b/application/engine/bo/UserPropertyBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux
+    Copyright 2018 Cédric Levieux
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class UserPropertyBo {

--- a/application/engine/bo/VoteBo.php
+++ b/application/engine/bo/VoteBo.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class VoteBo {

--- a/application/engine/modules/groupsource/CustomGroupSource.php
+++ b/application/engine/modules/groupsource/CustomGroupSource.php
@@ -1,20 +1,20 @@
 <?php /*
     Copyright 2015-2017 Cédric Levieux, Parti Pirate
-    
+
     This file is part of Congressus.
-    
+
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
     
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class CustomGroupSource {

--- a/application/engine/modules/groupsource/GaletteAllMembersGroupSource.php
+++ b/application/engine/modules/groupsource/GaletteAllMembersGroupSource.php
@@ -1,20 +1,20 @@
 <?php /*
     Copyright 2018-2019 Cédric Levieux, Parti Pirate
-    
+
     This file is part of Congressus.
-    
+
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GaletteAllMembersGroupSource {

--- a/application/engine/modules/groupsource/GaletteGroupSource.php
+++ b/application/engine/modules/groupsource/GaletteGroupSource.php
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
     
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GaletteGroupSource {

--- a/application/engine/modules/groupsource/GroupSourceFactory.php
+++ b/application/engine/modules/groupsource/GroupSourceFactory.php
@@ -1,20 +1,20 @@
 <?php /*
     Copyright 2015-2017 Cédric Levieux, Parti Pirate
-    
+
     This file is part of Congressus.
-    
+
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
-    
+
     Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GroupSourceFactory {

--- a/application/engine/modules/groupsource/PersonaeGroupSource.php
+++ b/application/engine/modules/groupsource/PersonaeGroupSource.php
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
     
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class PersonaeGroupSource {

--- a/application/engine/modules/groupsource/PersonaeThemeSource.php
+++ b/application/engine/modules/groupsource/PersonaeThemeSource.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
-	
-	This file is part of Congressus.
-	
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
+
+    This file is part of Congressus.
+
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
 	the Free Software Foundation, either version 3 of the License, or
 	(at your option) any later version.
-	
+
 	Congressus is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 	GNU General Public License for more details.
-	
+
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class PersonaeThemeSource {

--- a/application/engine/modules/usersource/CustomUserSource.php
+++ b/application/engine/modules/usersource/CustomUserSource.php
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
     
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 /**
  * 

--- a/application/engine/modules/usersource/GaletteUserSource.php
+++ b/application/engine/modules/usersource/GaletteUserSource.php
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
     
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GaletteUserSource {

--- a/application/engine/modules/usersource/InternalUserSource.php
+++ b/application/engine/modules/usersource/InternalUserSource.php
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
     
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class InternalUserSource {

--- a/application/engine/modules/usersource/UserSourceFactory.php
+++ b/application/engine/modules/usersource/UserSourceFactory.php
@@ -14,7 +14,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class UserSourceFactory {

--- a/application/engine/requests/sql/MySQLQuery.php
+++ b/application/engine/requests/sql/MySQLQuery.php
@@ -16,7 +16,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class MySQLQuery {

--- a/application/engine/requests/sql/QueryFactory.php
+++ b/application/engine/requests/sql/QueryFactory.php
@@ -16,7 +16,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class QueryFactory {

--- a/application/engine/utils/EventStackUtils.php
+++ b/application/engine/utils/EventStackUtils.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2081 Cédric Levieux, Parti Pirate
+    Copyright 2015-2081 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 define("EVENT_JOIN", "join");

--- a/application/engine/utils/FormUtils.php
+++ b/application/engine/utils/FormUtils.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of PPMoney.
+    This file is part of PPMoney.
 
     PPMoney is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with PPMoney.  If not, see <http://www.gnu.org/licenses/>.
+    along with PPMoney.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function xssClean($data, $withStripTags = false)

--- a/application/engine/utils/GamifierClient.php
+++ b/application/engine/utils/GamifierClient.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Gamifier.
+    This file is part of Gamifier.
 
     Gamifier is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Gamifier.  If age, see <http://www.gnu.org/licenses/>.
+    along with Gamifier.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class GamifierClient {

--- a/application/engine/utils/Merger.php
+++ b/application/engine/utils/Merger.php
@@ -15,7 +15,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function mb_str_split($str, $len = 1) {

--- a/application/engine/utils/PersonaeClient.php
+++ b/application/engine/utils/PersonaeClient.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 class PersonaeClient {

--- a/application/engine/utils/QuorumUtils.php
+++ b/application/engine/utils/QuorumUtils.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 require_once("language/language.php");

--- a/application/engine/utils/SessionUtils.php
+++ b/application/engine/utils/SessionUtils.php
@@ -1,20 +1,21 @@
-<?php /*
-	Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+<?php /*/*
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
+*/
 */
 
 class SessionUtils {

--- a/application/engine/utils/bootstrap_forms.php
+++ b/application/engine/utils/bootstrap_forms.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2014 Cédric Levieux, Parti Pirate
+    Copyright 2014 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function addAlertDialog($id, $text, $level = "default") {

--- a/application/export.php
+++ b/application/export.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2017 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
+    Copyright 2017 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 session_start();
 

--- a/application/footer.php
+++ b/application/footer.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 

--- a/application/forgotten.php
+++ b/application/forgotten.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 require_once("engine/utils/SessionUtils.php");

--- a/application/getAvatar.php
+++ b/application/getAvatar.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 require_once("config/database.php");

--- a/application/group.php
+++ b/application/group.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/groupMeetings.php
+++ b/application/groupMeetings.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/groups.php
+++ b/application/groups.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $limit = "all";

--- a/application/header.php
+++ b/application/header.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 session_start();
 

--- a/application/ident.php
+++ b/application/ident.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 ?>

--- a/application/index.php
+++ b/application/index.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/install/Installer.php
+++ b/application/install/Installer.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Installer.
+    This file is part of Congressus.
 
-    Installer is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Installer is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Installer.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!file_exists("config/config.php")) {

--- a/application/install/Schema.php
+++ b/application/install/Schema.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2018-2019 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Installer.
+    This file is part of Congressus.
 
-    Installer is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Installer is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Installer.  If not, see <http://www.gnu.org/licenses/>.
+    along with Installer.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 // This file contains the schema of the bdd, used for deploy or update of the database

--- a/application/language/ca/langages.php
+++ b/application/language/ca/langages.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["language_fr"] = "Français";  // francès

--- a/application/language/cs/langages.php
+++ b/application/language/cs/langages.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["language_fr"] = "Français";  // francouzský

--- a/application/language/de/langages.php
+++ b/application/language/de/langages.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["language_fr"] = "Français";  // Französisch

--- a/application/language/en/CustomGroupSource.php
+++ b/application/language/en/CustomGroupSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["cgs_choose"] = "Select a group";

--- a/application/language/en/GaletteGroupSource.php
+++ b/application/language/en/GaletteGroupSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["ggs_choose"] = "Select a group";

--- a/application/language/en/PersonaeGroupSource.php
+++ b/application/language/en/PersonaeGroupSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["pgs_choose"] = "Select a group";

--- a/application/language/en/PersonaeThemeSource.php
+++ b/application/language/en/PersonaeThemeSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["pts_choose"] = "Select a theme";

--- a/application/language/en/about.php
+++ b/application/language/en/about.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["about_what_s_congressus_legend"] = "What is Congressus ?";

--- a/application/language/en/admin.php
+++ b/application/language/en/admin.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["administration_guide"] = "Application Settings";

--- a/application/language/en/connect.php
+++ b/application/language/en/connect.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["breadcrumb_connect"] = "Connect";

--- a/application/language/en/date.php
+++ b/application/language/en/date.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["Sunday"] = "Sunday";

--- a/application/language/en/delegation_advanced.php
+++ b/application/language/en/delegation_advanced.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["conditional_remove_conditional"] = "Remove a delegation rule";

--- a/application/language/en/index.html
+++ b/application/language/en/index.html
@@ -1,20 +1,20 @@
 <!--
-    Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <html>
 <head>

--- a/application/language/en/langages.php
+++ b/application/language/en/langages.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["language_fr"] = "Français";  // French

--- a/application/language/en/main.php
+++ b/application/language/en/main.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["date_format"] = "m/d/Y";

--- a/application/language/en/register.php
+++ b/application/language/en/register.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["breadcrumb_register"] = "Sign in";

--- a/application/language/en/skills.php
+++ b/application/language/en/skills.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["skill_level_concepts"] = "Notions";

--- a/application/language/en/theme.php
+++ b/application/language/en/theme.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["menu_groups"]                     = "Delegations";

--- a/application/language/en/vote.php
+++ b/application/language/en/vote.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["vote_yes"]       = "Yes";

--- a/application/language/es/langages.php
+++ b/application/language/es/langages.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["language_fr"] = "Français";  // francés

--- a/application/language/fr/CustomGroupSource.php
+++ b/application/language/fr/CustomGroupSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["cgs_choose"] = "Veuillez choisir un groupe";

--- a/application/language/fr/GaletteGroupSource.php
+++ b/application/language/fr/GaletteGroupSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["ggs_choose"] = "Veuillez choisir un groupe";

--- a/application/language/fr/PersonaeGroupSource.php
+++ b/application/language/fr/PersonaeGroupSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["pgs_choose"] = "Veuillez choisir un groupe";

--- a/application/language/fr/PersonaeThemeSource.php
+++ b/application/language/fr/PersonaeThemeSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["pts_choose"] = "Veuillez choisir un thème";

--- a/application/language/fr/about.php
+++ b/application/language/fr/about.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["about_what_s_congressus_legend"] = "Qu'est ce que Congressus ?";

--- a/application/language/fr/admin.php
+++ b/application/language/fr/admin.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["administration_guide"] = "Gérez ici les informations de gestion de l'application";

--- a/application/language/fr/connect.php
+++ b/application/language/fr/connect.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["breadcrumb_connect"] = "Se connecter";

--- a/application/language/fr/date.php
+++ b/application/language/fr/date.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["Sunday"] = "Dimanche";

--- a/application/language/fr/delegation_advanced.php
+++ b/application/language/fr/delegation_advanced.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["conditional_remove_conditional"] = "Retirer une règle de délégation";

--- a/application/language/fr/index.html
+++ b/application/language/fr/index.html
@@ -1,20 +1,20 @@
 <!--
-    Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <html>
 <head>

--- a/application/language/fr/langages.php
+++ b/application/language/fr/langages.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["language_fr"] = "Français";  // Français

--- a/application/language/fr/main.php
+++ b/application/language/fr/main.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["date_format"] = "d/m/Y";

--- a/application/language/fr/register.php
+++ b/application/language/fr/register.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["breadcrumb_register"] = "Enregistrement";

--- a/application/language/fr/skills.php
+++ b/application/language/fr/skills.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["skill_level_concepts"] = "Notions";

--- a/application/language/fr/theme.php
+++ b/application/language/fr/theme.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["menu_groups"]                     = "Délégations";

--- a/application/language/fr/vote.php
+++ b/application/language/fr/vote.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["vote_yes"]       = "Oui";

--- a/application/language/index.html
+++ b/application/language/index.html
@@ -1,20 +1,20 @@
 <!--
-    Copyright 2014 Cédric Levieux, Jérémy Collot, ArmagNet
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-    This file is part of OpenTweetBar.
+    This file is part of Congressus.
 
-    OpenTweetBar is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    OpenTweetBar is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with OpenTweetBar.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <html>
 <head>

--- a/application/language/language.php
+++ b/application/language/language.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2014-2019 Cédric Levieux, Parti Pirate
+    Copyright 2014-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (isset($lang)) {

--- a/application/language/sv/langages.php
+++ b/application/language/sv/langages.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $lang["language_fr"] = "Français";  // franska

--- a/application/location_form.php
+++ b/application/location_form.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 @include_once("config/mumble.structure.php");

--- a/application/meeting.php
+++ b/application/meeting.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/meeting/addAgendaFrom_modal.php
+++ b/application/meeting/addAgendaFrom_modal.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018-2019 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 <style>

--- a/application/meeting/addTag_modal.php
+++ b/application/meeting/addTag_modal.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 <style>

--- a/application/meeting/do_addAgendaPoint.php
+++ b/application/meeting/do_addAgendaPoint.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addChat.php
+++ b/application/meeting/do_addChat.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addCoAuthor.php
+++ b/application/meeting/do_addCoAuthor.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addConclusion.php
+++ b/application/meeting/do_addConclusion.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addConstruction.php
+++ b/application/meeting/do_addConstruction.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addEvent.php
+++ b/application/meeting/do_addEvent.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addMotion.php
+++ b/application/meeting/do_addMotion.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addMotionProposition.php
+++ b/application/meeting/do_addMotionProposition.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addNotice.php
+++ b/application/meeting/do_addNotice.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addSource.php
+++ b/application/meeting/do_addSource.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_addTask.php
+++ b/application/meeting/do_addTask.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeAgendaPoint.php
+++ b/application/meeting/do_changeAgendaPoint.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeChat.php
+++ b/application/meeting/do_changeChat.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeConclusion.php
+++ b/application/meeting/do_changeConclusion.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeGuest.php
+++ b/application/meeting/do_changeGuest.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeMeeting.php
+++ b/application/meeting/do_changeMeeting.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeMotionProperty.php
+++ b/application/meeting/do_changeMotionProperty.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeMotionStatus.php
+++ b/application/meeting/do_changeMotionStatus.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeNotice.php
+++ b/application/meeting/do_changeNotice.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeOfficeMember.php
+++ b/application/meeting/do_changeOfficeMember.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeRights.php
+++ b/application/meeting/do_changeRights.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_changeTask.php
+++ b/application/meeting/do_changeTask.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_computeVote.old.php
+++ b/application/meeting/do_computeVote.old.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 //session_start();

--- a/application/meeting/do_computeVote.php
+++ b/application/meeting/do_computeVote.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 /*

--- a/application/meeting/do_copyMeeting.php
+++ b/application/meeting/do_copyMeeting.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $path = "../";

--- a/application/meeting/do_createMeeting.php
+++ b/application/meeting/do_createMeeting.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 session_start();

--- a/application/meeting/do_discoursePost.php
+++ b/application/meeting/do_discoursePost.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2017 Nino Treyssat-Vincent, Parti Pirate
+    Copyright 2017 Nino Treyssat-Vincent, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_exchangeAuthors.php
+++ b/application/meeting/do_exchangeAuthors.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Parti Pirate
+    Copyright 2018-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_export.php
+++ b/application/meeting/do_export.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 session_start();

--- a/application/meeting/do_externalChat.php
+++ b/application/meeting/do_externalChat.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2017-2018 Cédric Levieux, Parti Pirate
+    Copyright 2017-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_finishTask.php
+++ b/application/meeting/do_finishTask.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_getAgenda.php
+++ b/application/meeting/do_getAgenda.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_getAgendaPoint.php
+++ b/application/meeting/do_getAgendaPoint.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_getEvents.php
+++ b/application/meeting/do_getEvents.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_getMeetings.php
+++ b/application/meeting/do_getMeetings.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_getPeople.php
+++ b/application/meeting/do_getPeople.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_getTags.php
+++ b/application/meeting/do_getTags.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_getTasks.php
+++ b/application/meeting/do_getTasks.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_noticePeople.php
+++ b/application/meeting/do_noticePeople.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_openDebate.php
+++ b/application/meeting/do_openDebate.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2018 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
+    Copyright 2018 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_ping.php
+++ b/application/meeting/do_ping.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeAgendaPoint.php
+++ b/application/meeting/do_removeAgendaPoint.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeChat.php
+++ b/application/meeting/do_removeChat.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeCoAuthor.php
+++ b/application/meeting/do_removeCoAuthor.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeConclusion.php
+++ b/application/meeting/do_removeConclusion.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeMotion.php
+++ b/application/meeting/do_removeMotion.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeMotionProposition.php
+++ b/application/meeting/do_removeMotionProposition.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeNotice.php
+++ b/application/meeting/do_removeNotice.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeSpeaker.php
+++ b/application/meeting/do_removeSpeaker.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeTask.php
+++ b/application/meeting/do_removeTask.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_removeVotes.php
+++ b/application/meeting/do_removeVotes.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_requestSpeaking.php
+++ b/application/meeting/do_requestSpeaking.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_setAdvice.php
+++ b/application/meeting/do_setAdvice.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_setSpeaking.php
+++ b/application/meeting/do_setSpeaking.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_showPreview.php
+++ b/application/meeting/do_showPreview.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_trashMotion.php
+++ b/application/meeting/do_trashMotion.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_vote.php
+++ b/application/meeting/do_vote.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_voteConstruction.php
+++ b/application/meeting/do_voteConstruction.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If age, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (!isset($api)) exit();

--- a/application/meeting/do_wikiPost.php
+++ b/application/meeting/do_wikiPost.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2017 Cédric Levieux, Parti Pirate
+    Copyright 2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 require_once("config/mediawiki.php");

--- a/application/meeting/export_templates/discourse.php
+++ b/application/meeting/export_templates/discourse.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2017 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
+    Copyright 2017 Cédric Levieux, Nino Treyssat-Vincent, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function showMotion($motions, $id, &$voters) {

--- a/application/meeting/export_templates/html.php
+++ b/application/meeting/export_templates/html.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function showMotion($motions, $id, &$voters) {

--- a/application/meeting/export_templates/markdown.php
+++ b/application/meeting/export_templates/markdown.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018  Cédric Levieux, Parti Pirate
+    Copyright 2015-2018  Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function showMotion($motions, $id, &$voters) {

--- a/application/meeting/export_templates/pdf.php
+++ b/application/meeting/export_templates/pdf.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
 	Congressus is free software: you can redistribute it and/or modify
 	it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
 	GNU General Public License for more details.
 
 	You should have received a copy of the GNU General Public License
-	along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+	along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 function showMotion($motions, $id, &$voters) {

--- a/application/meeting/export_templates/pdf_post.php
+++ b/application/meeting/export_templates/pdf_post.php
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 //$content = "BOUH";

--- a/application/meeting/setMotionDeadline_modal.php
+++ b/application/meeting/setMotionDeadline_modal.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 <style>

--- a/application/meeting/setQuorum_modal.php
+++ b/application/meeting/setQuorum_modal.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 require_once("engine/utils/QuorumUtils.php");

--- a/application/meeting_api.php
+++ b/application/meeting_api.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/member.php
+++ b/application/member.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/myBadges.php
+++ b/application/myBadges.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/myMeetings.php
+++ b/application/myMeetings.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/myVotes.php
+++ b/application/myVotes.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/mypreferences.php
+++ b/application/mypreferences.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 require_once("engine/utils/SessionUtils.php");

--- a/application/notice.php
+++ b/application/notice.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 require_once("config/database.php");

--- a/application/pad/do_receiveEvent.php
+++ b/application/pad/do_receiveEvent.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $memcache = openMemcacheConnection();

--- a/application/pad/do_sendEvent.php
+++ b/application/pad/do_sendEvent.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2019 Cédric Levieux, Parti Pirate
+    Copyright 2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 $memcache = openMemcacheConnection();

--- a/application/page.php
+++ b/application/page.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/personae_api.php
+++ b/application/personae_api.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2017 Cédric Levieux, Parti Pirate
+    Copyright 2015-2017 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/register.php
+++ b/application/register.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 require_once("engine/utils/SessionUtils.php");

--- a/application/search.php
+++ b/application/search.php
@@ -1,7 +1,7 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/search_member.php
+++ b/application/search_member.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015 Cédric Levieux, Parti Pirate
+    Copyright 2015 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);

--- a/application/theme.php
+++ b/application/theme.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 include_once("header.php");
 

--- a/application/theme/theme_admin.php
+++ b/application/theme/theme_admin.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 

--- a/application/theme/theme_user.php
+++ b/application/theme/theme_user.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 

--- a/application/theme/theme_user_delegation.php
+++ b/application/theme/theme_user_delegation.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 

--- a/application/theme/theme_user_delegation_advanced.php
+++ b/application/theme/theme_user_delegation_advanced.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2019 Cédric Levieux, Parti Pirate
+    Copyright 2015-2019 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 if (isset($config["tags"]["url"])) {

--- a/application/theme/theme_user_delegation_standard.php
+++ b/application/theme/theme_user_delegation_standard.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 

--- a/application/theme/theme_user_fixation.php
+++ b/application/theme/theme_user_fixation.php
@@ -1,20 +1,20 @@
 <?php /*
-	Copyright 2015-2018 Cédric Levieux, Parti Pirate
+    Copyright 2015-2018 Cédric Levieux, Parti Pirate
 
-	This file is part of Personae.
+    This file is part of Congressus.
 
-    Personae is free software: you can redistribute it and/or modify
+    Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    Personae is distributed in the hope that it will be useful,
+    Congressus is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Personae.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 ?>
 

--- a/application/themes/dark/css/style.css
+++ b/application/themes/dark/css/style.css
@@ -1,7 +1,7 @@
 /*
-	Copyright 2018 Cédric Levieux
+    Copyright 2018 Cédric Levieux
 
-	This file is part of Congressus.
+    This file is part of Congressus.
 
     Congressus is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with Congressus.  If not, see <http://www.gnu.org/licenses/>.
+    along with Congressus.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 body {


### PR DESCRIPTION
Much of the copyright/license information was somehow about OpenTweetBar not Congressus.

I also added the year 2019 and "Cédric Levieux, Parti Pirate" instead of other authors.

Also all of the comment now uses spaces and not both spaces and tabs for indentation.

Changed link to http://www.gnu.org/licenses/ to https.

There are more copyright notices to other projects that I didn't change.